### PR TITLE
define observation clustering strategy and record ADR-0006

### DIFF
--- a/docs/OBSERVATION_CLUSTERING.md
+++ b/docs/OBSERVATION_CLUSTERING.md
@@ -1,0 +1,122 @@
+# Observation Clustering Strategy
+
+This document defines the canonical strategy for assigning `Observation` records to `Friction` aggregates.
+
+## Scope
+
+- Applies to clustering behavior in `FrictionService`.
+- Defines assignment, deduplication, merge/split criteria, confidence thresholds, and failure paths.
+- Complements (does not replace) event and read-model contracts in canonical docs.
+
+## Inputs and Feature Signals
+
+Each candidate `Observation` is scored against existing `Friction` aggregates using a weighted feature set:
+
+- Semantic similarity of normalized text content (embedding cosine similarity)
+- Lexical overlap of keyphrases/tokens after normalization
+- Provenance proximity (source/subreddit/category alignment)
+- Temporal proximity (observation timestamp relative to recent cluster activity)
+
+### Normalization Baseline
+
+- Lowercase and whitespace normalization
+- URL canonicalization for provenance URI
+- Remove formatting noise and platform boilerplate
+- Preserve domain terms and product names as meaningful tokens
+
+## Assignment Pipeline
+
+1. Validate required observation fields (content, timestamp, provenance URI/source).
+2. Run deduplication check (hard duplicate rejection first).
+3. Score candidate observation against active frictions.
+4. Select best candidate friction and assignment confidence.
+5. Apply threshold rules:
+   - high confidence -> attach to existing friction
+   - medium confidence -> attach with review marker
+   - low confidence -> create new friction
+6. Emit events for accepted/rejected paths.
+
+## Deduplication Logic
+
+### Hard Duplicate
+
+Reject as duplicate if any of the following match an existing observation:
+
+- Same canonical provenance URI
+- Same external source identifier
+- Same normalized content hash and timestamp bucket
+
+Hard duplicates must emit `DuplicateDetected` and must not update friction metrics.
+
+### Near Duplicate
+
+If semantic similarity is extremely high (`>= 0.95`) and provenance source/time are near-identical, treat as duplicate and emit `ObservationRejected` with duplicate reason.
+
+## Confidence Thresholds and Fallback
+
+Use three confidence bands:
+
+- `>= 0.78` high confidence: assign to best-matching existing friction
+- `0.60 - 0.77` medium confidence: assign to existing friction and mark as low-confidence assignment metadata
+- `< 0.60` low confidence: create a new friction aggregate
+
+Fallback rules:
+
+- If no candidate friction exists, create a new friction.
+- If feature extraction fails, reject observation and emit failure path event.
+- If scoring fails unexpectedly, emit `FrictionUpdateFailed` with context.
+
+## Merge and Split Criteria
+
+### Merge Criteria
+
+Two frictions become merge candidates when all are true:
+
+- centroid/descriptor similarity `>= 0.85`
+- overlapping key observations across a rolling window
+- trend direction alignment over recent intervals
+
+Merge execution occurs as an explicit service action and emits standard `FrictionUpdated` events.
+
+### Split Criteria
+
+A friction becomes split candidate when:
+
+- internal semantic variance exceeds configured threshold
+- two stable sub-clusters persist across multiple windows
+
+Split behavior is optional for MVP; if disabled, mark for review metadata only.
+
+## Failure and Rejection Paths
+
+Use explicit fail-fast outcomes:
+
+- Missing required fields -> `ObservationRejected`
+- Hard/near duplicate -> `DuplicateDetected` or `ObservationRejected`
+- Feature extraction failure -> `ObservationRejected`
+- Scoring/runtime failure during aggregate update -> `FrictionUpdateFailed`
+
+Failure payloads must include actionable context (source, observation identifiers, reason category).
+
+## Event Emission Summary
+
+- Success assignment -> `ObservationCreated`, then `FrictionUpdated`
+- Duplicate path -> `DuplicateDetected` or `ObservationRejected`
+- Invalid observation -> `ObservationRejected`
+- Processing failure -> `FrictionUpdateFailed`
+
+## Testability Contract
+
+Implementations should be testable through deterministic cases:
+
+- high-confidence assignment to existing friction
+- medium-confidence assignment path
+- low-confidence new-friction creation path
+- hard duplicate rejection
+- malformed observation rejection
+- scoring failure emitting `FrictionUpdateFailed`
+
+## Tuning Notes
+
+- Thresholds above are canonical defaults and may be tuned via config with ADR-backed change.
+- Any threshold or feature-weight change must preserve event compatibility and be documented.

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ This directory is the single source of truth for shared product, domain, and arc
 - [Technical and Conceptual Overview](./friction-technical-and-conceptual-overview.md)
 - [SPI Contract](./SPI.md)
 - [Read Model Contract](./READ_MODELS.md)
+- [Observation Clustering Strategy](./OBSERVATION_CLUSTERING.md)
 - [Repo Boundaries](./REPO_BOUNDARIES.md)
 - [Versioning Policy](./VERSIONING.md)
 - [Decision Records Index](./adr/README.md)

--- a/docs/adr/ADR-0006-observation-clustering-strategy.md
+++ b/docs/adr/ADR-0006-observation-clustering-strategy.md
@@ -1,0 +1,42 @@
+# ADR-0006 Observation Clustering Strategy
+
+- Status: Accepted
+- Date: 2026-03-08
+
+## Context
+
+Observation clustering was previously an open question in the technical overview. Without a defined strategy, friction assignment can drift, reduce reproducibility, and weaken auditability.
+
+## Decision
+
+Adopt a weighted feature clustering strategy with explicit confidence thresholds and fail-fast rejection paths.
+
+Key policy choices:
+
+- Weighted signals: semantic similarity, lexical overlap, provenance proximity, temporal proximity
+- Hard duplicate rejection before scoring
+- Confidence bands:
+  - `>= 0.78`: assign to existing friction
+  - `0.60 - 0.77`: assign with low-confidence marker
+  - `< 0.60`: create new friction
+- Explicit merge criteria and optional split criteria for non-MVP phases
+- Failure/rejection outcomes mapped to canonical events (`ObservationRejected`, `DuplicateDetected`, `FrictionUpdateFailed`)
+
+## Consequences
+
+- Clustering behavior is now explicit and testable.
+- Assignment outcomes are more consistent and auditable.
+- Threshold tuning now requires governance and documentation updates.
+- Medium-confidence assignments introduce a review/tuning surface that must be monitored.
+
+## Tradeoffs
+
+- Fixed thresholds improve consistency but may require periodic retuning by domain.
+- Additional feature extraction/scoring logic increases implementation complexity.
+- Split behavior deferred for MVP limits automatic correction of heterogeneous frictions.
+
+## References
+
+- [OBSERVATION_CLUSTERING.md](../OBSERVATION_CLUSTERING.md)
+- [friction-technical-and-conceptual-overview.md](../friction-technical-and-conceptual-overview.md)
+- [friction-event-driven-architecture.md](../friction-event-driven-architecture.md)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -9,3 +9,4 @@ Architecture Decision Records (ADRs) are the primary decision log for shared Fri
 - [ADR-0003 EO Naming Constraints](./ADR-0003-eo-naming-constraints.md)
 - [ADR-0004 Read Model Interfaces as Pluggable Contracts](./ADR-0004-read-model-pluggable-interfaces.md)
 - [ADR-0005 Label-Driven Versioning Policy](./ADR-0005-label-driven-versioning.md)
+- [ADR-0006 Observation Clustering Strategy](./ADR-0006-observation-clustering-strategy.md)

--- a/docs/friction-technical-and-conceptual-overview.md
+++ b/docs/friction-technical-and-conceptual-overview.md
@@ -220,7 +220,7 @@ sequenceDiagram
 
 ## 8. Open Questions & Assumptions
 
-* **Observation Clustering Logic:** The algorithm for grouping `Observation`s into a `Friction` aggregate is undefined. Options include keyword matching, NLP-based semantic similarity, or another method. This logic will reside in `FrictionService`.
+* **Observation Clustering Logic:** Defined in `OBSERVATION_CLUSTERING.md` and governed by `ADR-0006`.
 * **Descriptor Generation:** How the `Friction.descriptor` string is derived is not specified. Likely from the most common terms or representative phrases in its observations.
 * **Merge Strategy:** The behavior of `Friction.mergeWith()` is not fully defined. It must be clarified what triggers a merge—an external process, user action, or automated rule—when two frictions are duplicates.
 * **Metrics Calculation Details:** Specific formulas and weighting factors for `intensity`, `trend`, and other metrics are not finalized. The system must also define metrics behavior for a `Friction` with fewer than two observations (e.g., default metrics or null-safe values).


### PR DESCRIPTION
- Added canonical clustering spec: `docs/OBSERVATION_CLUSTERING.md`.
- Documented clustering contract details:
  - input features/signals
  - deduplication logic (hard + near duplicate)
  - assignment confidence thresholds and fallback behavior
  - merge/split criteria
  - failure/rejection paths and emitted events
  - testability contract and tuning notes
- Added ADR: `docs/adr/ADR-0006-observation-clustering-strategy.md` with rationale, tradeoffs, and consequences.
- Updated docs indexes:
  - `docs/README.md` now links to clustering spec
  - `docs/adr/README.md` now links ADR-0006
- Updated technical overview to remove clustering from unresolved questions and point to canonical spec + ADR.