### PR TITLE
formalize metrics semantics and edge-case policy with ADR-0007

### DIFF
--- a/docs/METRICS_SEMANTICS.md
+++ b/docs/METRICS_SEMANTICS.md
@@ -1,0 +1,136 @@
+# Metrics Semantics and Edge-Case Policy
+
+This document defines canonical metric behavior for `Friction` aggregates and projection consistency.
+
+## Scope
+
+- Applies to metric computation for `FrictionMetrics`.
+- Defines semantics, edge-case handling, recalculation triggers, and projection expectations.
+- Provides implementation-neutral rules for consistent behavior across adapters/services.
+
+## Canonical Metrics
+
+## 1) Prevalence
+
+Definition:
+
+- Count of valid, non-duplicate observations assigned to a friction within the active analysis window.
+
+Rules:
+
+- Increment by 1 for each accepted observation assignment.
+- Do not increment for duplicates or rejected observations.
+- If an observation is removed via correction workflow, recompute prevalence from persisted observation set.
+
+## 2) Intensity
+
+Definition:
+
+- Normalized weighted signal of how strongly the friction is expressed.
+
+Canonical formula:
+
+- For each observation `o`, compute `signal(o)` from configured factors (engagement, textual severity proxy, repetition context).
+- Maintain exponentially decayed aggregate:
+  - `intensity_t = intensity_(t-1) * decay + signal(o_t)`
+- Normalize intensity into `[0, 1]` range for projection output.
+
+Rules:
+
+- `decay` must be fixed per run configuration and documented.
+- Missing optional engagement factors default to neutral contribution, not zeroing entire signal.
+
+## 3) Persistence
+
+Definition:
+
+- Duration across first and latest accepted observation timestamps.
+
+Canonical formula:
+
+- `persistence = latestTimestamp - firstTimestamp`
+
+Rules:
+
+- Requires valid timestamps on included observations.
+- If only one valid timestamp exists, persistence is `PT0S`.
+- If timestamps are missing for all candidate observations, persistence is unavailable and computation must follow failure/rejection policy.
+
+## 4) Trend and Confidence
+
+Definition:
+
+- Trend is slope of observation activity/intensity over time buckets.
+- Confidence is fit quality for slope estimate.
+
+Canonical method:
+
+- Build rolling time series by fixed bucket (for example hourly/daily by config).
+- Compute linear regression slope on bucketed values.
+- Confidence is regression quality metric (`r^2`) in `[0, 1]`.
+
+Rules:
+
+- Minimum data points for trend computation: 2 buckets.
+- If fewer than 2 valid buckets, trend is unavailable and handled via edge-case policy.
+
+## Edge-Case Policy
+
+## Insufficient Observations
+
+- `prevalence`: valid (0 or 1+).
+- `intensity`: valid if at least one accepted observation signal exists.
+- `persistence`: `PT0S` when exactly one valid timestamp.
+- `trend/confidence`: unavailable when fewer than 2 valid time buckets.
+
+Handling:
+
+- Unavailable trend/confidence must not crash pipeline.
+- Emit `FrictionUpdated` with explicit "unavailable trend" metadata where allowed by projection schema.
+
+## Missing Timestamps or Metadata
+
+- Missing required timestamp/provenance fields for a candidate observation -> reject observation (`ObservationRejected`).
+- Missing optional signal inputs (for intensity factors) -> use neutral defaults.
+- Observation accepted only if mandatory invariants remain satisfied.
+
+## Failed Recalculation Paths
+
+- If metric recalculation fails at aggregate update stage, emit `FrictionUpdateFailed` with reason category and context.
+- Do not mutate aggregate/read model on failed recalculation path.
+- Keep last known valid metric snapshot available for query consistency until next successful update.
+
+## Recalculation Triggers
+
+Recalculate friction metrics when any of the following occurs:
+
+- New observation accepted into a friction.
+- Explicit friction merge operation completes.
+- Explicit correction/removal workflow changes observation set.
+
+Do not recalculate on:
+
+- Duplicate detection path.
+- Observation rejection path.
+
+## Projection Update Expectations
+
+- Successful metric recalculation -> emit `FrictionUpdated` and update `FrictionSummary` projection.
+- Observation detail projections may update independently but must remain provenance-consistent.
+- Failed recalculation -> emit `FrictionUpdateFailed`; projection retains previous valid metrics.
+- Projection handlers must treat missing/unavailable trend fields as explicit state, not implicit errors.
+
+## Determinism and Testability
+
+Implementations should provide deterministic coverage for:
+
+- one-observation case (`persistence=PT0S`, trend unavailable)
+- two-plus observation trend computation
+- missing required timestamp rejection
+- duplicate non-impact on prevalence/intensity
+- failed recalculation path preserving last valid projection state
+
+## Change Control
+
+- Any formula, threshold, decay, or bucket-policy change requires ADR update and spec revision.
+- Backward compatibility expectations for projection consumers must be documented before rollout.

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@ This directory is the single source of truth for shared product, domain, and arc
 - [SPI Contract](./SPI.md)
 - [Read Model Contract](./READ_MODELS.md)
 - [Observation Clustering Strategy](./OBSERVATION_CLUSTERING.md)
+- [Metrics Semantics and Edge-Case Policy](./METRICS_SEMANTICS.md)
 - [Repo Boundaries](./REPO_BOUNDARIES.md)
 - [Versioning Policy](./VERSIONING.md)
 - [Decision Records Index](./adr/README.md)

--- a/docs/adr/ADR-0007-metrics-semantics-and-edge-cases.md
+++ b/docs/adr/ADR-0007-metrics-semantics-and-edge-cases.md
@@ -1,0 +1,40 @@
+# ADR-0007 Metrics Semantics and Edge-Case Policy
+
+- Status: Accepted
+- Date: 2026-03-08
+
+## Context
+
+Metric behavior across prevalence, intensity, persistence, and trend was partially described but not fully formalized for edge cases. This created ambiguity for implementation and projection consistency.
+
+## Decision
+
+Adopt a canonical metrics semantics policy defined in `METRICS_SEMANTICS.md`.
+
+Key decisions:
+
+- Prevalence counts accepted, non-duplicate observations.
+- Intensity uses decayed weighted signal with normalized output.
+- Persistence is timestamp-span with `PT0S` single-point behavior.
+- Trend/confidence uses bucketed linear regression with minimum data requirements.
+- Explicit edge-case behavior for insufficient data, missing required metadata, and failed recalculation paths.
+- Projection updates must preserve last valid metric snapshot on recalculation failure.
+
+## Consequences
+
+- Metric outputs are now implementation-consistent across services/adapters.
+- Failure behavior is explicit and auditable via domain events.
+- Projection consumers can rely on stable semantics for unavailable trend states.
+- Formula/policy changes now require governance via ADR update.
+
+## Constraints
+
+- Trend/confidence are unavailable below minimum bucket count and must be represented explicitly.
+- Missing required provenance/timestamp fields trigger rejection, not partial metric updates.
+- Failed recalculation paths must not mutate persisted metric projections.
+
+## References
+
+- [METRICS_SEMANTICS.md](../METRICS_SEMANTICS.md)
+- [friction-metrics-incremental-computation.md](../friction-metrics-incremental-computation.md)
+- [friction-technical-and-conceptual-overview.md](../friction-technical-and-conceptual-overview.md)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -10,3 +10,4 @@ Architecture Decision Records (ADRs) are the primary decision log for shared Fri
 - [ADR-0004 Read Model Interfaces as Pluggable Contracts](./ADR-0004-read-model-pluggable-interfaces.md)
 - [ADR-0005 Label-Driven Versioning Policy](./ADR-0005-label-driven-versioning.md)
 - [ADR-0006 Observation Clustering Strategy](./ADR-0006-observation-clustering-strategy.md)
+- [ADR-0007 Metrics Semantics and Edge-Case Policy](./ADR-0007-metrics-semantics-and-edge-cases.md)

--- a/docs/friction-technical-and-conceptual-overview.md
+++ b/docs/friction-technical-and-conceptual-overview.md
@@ -223,7 +223,7 @@ sequenceDiagram
 * **Observation Clustering Logic:** Defined in `OBSERVATION_CLUSTERING.md` and governed by `ADR-0006`.
 * **Descriptor Generation:** How the `Friction.descriptor` string is derived is not specified. Likely from the most common terms or representative phrases in its observations.
 * **Merge Strategy:** The behavior of `Friction.mergeWith()` is not fully defined. It must be clarified what triggers a merge—an external process, user action, or automated rule—when two frictions are duplicates.
-* **Metrics Calculation Details:** Specific formulas and weighting factors for `intensity`, `trend`, and other metrics are not finalized. The system must also define metrics behavior for a `Friction` with fewer than two observations (e.g., default metrics or null-safe values).
+* **Metrics Calculation Details:** Defined in `METRICS_SEMANTICS.md` and governed by `ADR-0007`.
 * **Security & Access Control:** Strategies for securing sensitive configuration data (`SourceConfig` may contain API keys) and controlling access to source configuration or friction data are not detailed.
 * **Scalability and Performance:** While horizontal scaling is assumed, specific strategies for data partitioning, high-volume ingestion, and efficient clustering are not defined.
 


### PR DESCRIPTION
- Added canonical metrics spec: `docs/METRICS_SEMANTICS.md`.
- Defined exact metric behavior for:
  - prevalence
  - intensity
  - persistence
  - trend/confidence
- Defined explicit edge-case handling for:
  - insufficient observations
  - missing required timestamps/metadata
  - failed recalculation paths
- Documented recalculation triggers and projection update expectations.
- Added ADR: `docs/adr/ADR-0007-metrics-semantics-and-edge-cases.md` with rationale, constraints, and consequences.
- Updated indexes and references:
  - `docs/README.md` links metrics spec
  - `docs/adr/README.md` links ADR-0007
  - `friction-technical-and-conceptual-overview.md` now references metrics spec + ADR instead of listing metrics as undefined