### PR TITLE
define descriptor generation policy and record ADR-0008

### DIFF
--- a/docs/DESCRIPTOR_GENERATION.md
+++ b/docs/DESCRIPTOR_GENERATION.md
@@ -1,0 +1,107 @@
+# Friction Descriptor Generation Policy
+
+This document defines canonical rules for generating and updating `Friction.descriptor`.
+
+## Scope
+
+- Applies to descriptor synthesis in `FrictionService`.
+- Defines deterministic generation, update/rewrite policy, and stability controls.
+- Complements canonical clustering and metrics specs.
+
+## Input Signals for Descriptor Synthesis
+
+Descriptor candidates are derived from accepted observations assigned to a friction using weighted signals:
+
+- salient keyphrases (frequency and distinctiveness)
+- semantic centroid terms from cluster content embeddings
+- provenance context terms (domain/source cues when meaningful)
+- recency weighting to surface active phrasing
+
+Normalization baseline:
+
+- lowercase normalization for scoring only
+- punctuation/noise reduction for tokenization
+- preserve meaningful product/domain terms
+- remove platform boilerplate and stopword-only phrases
+
+## Deterministic Candidate Pipeline
+
+1. Build candidate phrase pool from latest valid observation set.
+2. Score phrases using fixed weighted formula.
+3. Rank descending and apply tie-breakers deterministically:
+   - higher distinctiveness first
+   - then higher frequency
+   - then lexical sort for stable output
+4. Select top candidate as descriptor.
+
+Output constraints:
+
+- concise phrase (target 3-12 words)
+- avoid URLs, user handles, and platform-specific markup
+- avoid purely sentiment-only descriptors (for example "users are angry")
+
+## Update/Rewrite Policy
+
+Descriptor recalculation triggers:
+
+- new observation accepted
+- friction merge completed
+- correction workflow modifies observation set
+
+Rewrite threshold policy:
+
+- only replace current descriptor when new candidate score exceeds current descriptor score by configured delta (`rewrite_delta`)
+- if below delta, retain existing descriptor to reduce churn
+
+Hard rewrite paths:
+
+- descriptor becomes invalid under policy constraints
+- merge operation produces dominant new cluster semantics
+
+## Stability Rules (Anti-Churn)
+
+- enforce minimum update interval (`descriptor_cooldown`) unless hard rewrite path applies
+- require score margin over existing descriptor (`rewrite_delta`) for non-hard rewrites
+- keep previous descriptor history for auditability
+- deterministic tie-breakers must yield same descriptor for same input state
+
+## Sparse/Noisy Cluster Fallback Behavior
+
+Sparse fallback:
+
+- if insufficient high-quality phrases, use template:
+  - `Recurring issue in <domain/source>`
+- mark fallback metadata for later refinement
+
+Noisy fallback:
+
+- if top candidates are low-confidence/noise, keep prior descriptor when available
+- otherwise use neutral fallback descriptor and emit low-confidence marker
+
+## Localization and Formatting Boundaries
+
+- canonical descriptor is stored as locale-neutral text
+- localization/translation is a presentation concern outside core descriptor generation
+- UI may format display casing; core output remains normalized policy output
+
+## Auditability and Traceability
+
+For each descriptor update, retain metadata:
+
+- selected candidate phrase
+- score and score margin vs prior descriptor
+- trigger reason (new observation, merge, correction)
+- timestamp and friction identity
+
+This metadata supports reproducibility and debugging of descriptor changes.
+
+## Failure Handling
+
+- failure in descriptor synthesis should not mutate descriptor state
+- emit failure context alongside standard failure path event handling (`FrictionUpdateFailed` where applicable)
+- retain last valid descriptor on synthesis failure
+
+## Change Control
+
+- Weight, threshold, or fallback policy changes require ADR-backed update.
+- Determinism guarantees must be preserved after policy changes.

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ This directory is the single source of truth for shared product, domain, and arc
 - [Read Model Contract](./READ_MODELS.md)
 - [Observation Clustering Strategy](./OBSERVATION_CLUSTERING.md)
 - [Metrics Semantics and Edge-Case Policy](./METRICS_SEMANTICS.md)
+- [Descriptor Generation Policy](./DESCRIPTOR_GENERATION.md)
 - [Repo Boundaries](./REPO_BOUNDARIES.md)
 - [Versioning Policy](./VERSIONING.md)
 - [Decision Records Index](./adr/README.md)

--- a/docs/adr/ADR-0008-descriptor-generation-policy.md
+++ b/docs/adr/ADR-0008-descriptor-generation-policy.md
@@ -1,0 +1,39 @@
+# ADR-0008 Friction Descriptor Generation Policy
+
+- Status: Accepted
+- Date: 2026-03-08
+
+## Context
+
+`Friction.descriptor` generation was previously unspecified, leading to ambiguity, unstable naming, and inconsistent UX/API representation across implementations.
+
+## Decision
+
+Adopt a deterministic descriptor generation policy based on weighted phrase synthesis with explicit rewrite thresholds and anti-churn controls.
+
+Key policy decisions:
+
+- fixed signal set for candidate phrase scoring
+- deterministic ranking and tie-breakers
+- rewrite only above configured score margin (`rewrite_delta`)
+- cooldown window to prevent frequent churn
+- explicit sparse/noisy fallback descriptors
+- locale-neutral canonical descriptor, presentation-localized downstream
+
+## Consequences
+
+- Descriptor behavior is now explicit and auditable.
+- Same observation set yields stable descriptor output.
+- Some semantic improvements may be delayed by anti-churn thresholds.
+- Policy tuning must follow documented governance updates.
+
+## Tradeoffs
+
+- Stability controls reduce churn but can slow responsiveness to emerging language shifts.
+- Deterministic constraints reduce ambiguity but may underfit nuanced semantic changes in edge cases.
+
+## References
+
+- [DESCRIPTOR_GENERATION.md](../DESCRIPTOR_GENERATION.md)
+- [OBSERVATION_CLUSTERING.md](../OBSERVATION_CLUSTERING.md)
+- [friction-technical-and-conceptual-overview.md](../friction-technical-and-conceptual-overview.md)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -11,3 +11,4 @@ Architecture Decision Records (ADRs) are the primary decision log for shared Fri
 - [ADR-0005 Label-Driven Versioning Policy](./ADR-0005-label-driven-versioning.md)
 - [ADR-0006 Observation Clustering Strategy](./ADR-0006-observation-clustering-strategy.md)
 - [ADR-0007 Metrics Semantics and Edge-Case Policy](./ADR-0007-metrics-semantics-and-edge-cases.md)
+- [ADR-0008 Friction Descriptor Generation Policy](./ADR-0008-descriptor-generation-policy.md)

--- a/docs/friction-technical-and-conceptual-overview.md
+++ b/docs/friction-technical-and-conceptual-overview.md
@@ -221,7 +221,7 @@ sequenceDiagram
 ## 8. Open Questions & Assumptions
 
 * **Observation Clustering Logic:** Defined in `OBSERVATION_CLUSTERING.md` and governed by `ADR-0006`.
-* **Descriptor Generation:** How the `Friction.descriptor` string is derived is not specified. Likely from the most common terms or representative phrases in its observations.
+* **Descriptor Generation:** Defined in `DESCRIPTOR_GENERATION.md` and governed by `ADR-0008`.
 * **Merge Strategy:** The behavior of `Friction.mergeWith()` is not fully defined. It must be clarified what triggers a merge—an external process, user action, or automated rule—when two frictions are duplicates.
 * **Metrics Calculation Details:** Defined in `METRICS_SEMANTICS.md` and governed by `ADR-0007`.
 * **Security & Access Control:** Strategies for securing sensitive configuration data (`SourceConfig` may contain API keys) and controlling access to source configuration or friction data are not detailed.


### PR DESCRIPTION
- Added canonical descriptor-generation spec: `docs/DESCRIPTOR_GENERATION.md`.
- Defined deterministic descriptor behavior including:
  - input signals for synthesis
  - update/rewrite policy on new observations
  - anti-churn stability rules
  - sparse/noisy fallback behavior
  - localization/formatting boundaries
  - failure handling and auditability metadata
- Added ADR: `docs/adr/ADR-0008-descriptor-generation-policy.md` with rationale, tradeoffs, and consequences.
- Updated docs indexes:
  - `docs/README.md` now links descriptor policy
  - `docs/adr/README.md` now links ADR-0008
- Updated technical overview open questions to reference descriptor policy + ADR instead of leaving descriptor generation unspecified.