### PR TITLE
define merge/split execution policy and record ADR-0009

### DIFF
--- a/docs/MERGE_SPLIT_POLICY.md
+++ b/docs/MERGE_SPLIT_POLICY.md
@@ -1,0 +1,125 @@
+# Friction Merge/Split Execution Policy
+
+This document defines canonical merge/split execution behavior for `Friction` aggregates.
+
+## Scope
+
+- Applies to merge/split orchestration in `FrictionService`.
+- Defines triggers, prerequisites, conflict/idempotency rules, events, and failure recovery.
+- Complements clustering and metrics semantics policies.
+
+## Merge Policy
+
+## Merge Triggers
+
+A merge operation may be initiated when any of the following conditions are met:
+
+- automated candidate detection meets merge threshold policy
+- explicit operator/workflow request references two compatible frictions
+- correction workflow identifies duplicate semantic clusters
+
+## Merge Prerequisites
+
+All must hold before execution:
+
+- both frictions exist and are active
+- no terminal conflict lock/state on either friction
+- merge candidate confidence is above configured minimum threshold
+- observation identity sets can be deduplicated deterministically
+
+## Merge Execution Semantics
+
+1. Lock merge scope for involved friction identities.
+2. Build merged observation set with deduplication.
+3. Recompute metrics and descriptor using canonical policies.
+4. Persist merged friction as new authoritative state.
+5. Mark source friction identities as merged/superseded.
+6. Emit merge outcome events.
+
+## Split Policy
+
+## Split Triggers
+
+Split candidate criteria include:
+
+- sustained internal semantic divergence above threshold
+- stable sub-clusters across configured time windows
+- explicit correction workflow request
+
+## MVP Status
+
+- Split execution is **disabled for MVP**.
+- MVP behavior: detect and mark split candidates with review metadata only.
+- No automatic split mutation is applied during MVP.
+
+## Conflict Handling and Idempotency
+
+## Conflict Handling
+
+Conflicts include:
+
+- stale operation against already-merged friction
+- overlapping operations on same friction identity
+- version/sequence mismatch at write boundary
+
+Conflict policy:
+
+- reject stale/conflicting operation with explicit conflict reason
+- do not partially mutate involved frictions on conflict
+
+## Idempotency Expectations
+
+- Merge request must be idempotent by operation key and friction pair identity.
+- Retried identical merge operations must converge to same terminal state.
+- Duplicate operation replays should return prior successful outcome metadata when available.
+
+## Event Emission Semantics
+
+## Merge Success
+
+Emit in order:
+
+- `FrictionMerged` (new event): `{targetFrictionId, sourceFrictionIds[], operationId}`
+- `FrictionUpdated`: merged metrics/descriptor payload for target friction
+- projection update events from projection service
+
+## Merge Rejection/Failure
+
+- conflict/stale request -> `FrictionMergeRejected` (new event)
+- execution failure after start -> `FrictionMergeFailed` (new event)
+- no projection mutation on rejected/failed merge paths
+
+## Split Candidate (MVP)
+
+- emit `FrictionSplitCandidateDetected` (new event) with candidate metadata
+- no `FrictionSplitCompleted` during MVP
+
+## Rollback/Recovery Behavior
+
+- Merge execution must be atomic at persistence boundary where supported.
+- If atomic commit is unavailable, use compensating recovery marker and restore prior authoritative state.
+- On failure after partial work:
+  - mark operation as failed with recovery-needed context
+  - prevent further merge attempts on same scope until recovery checkpoint clears
+- Recovery/replay must preserve idempotency guarantees.
+
+## Observability Requirements
+
+Capture:
+
+- merge attempts/success/rejected/failed counts
+- split-candidate detection counts
+- conflict reason distribution
+- operation latency and retry metrics
+
+Required operation context:
+
+- `operationId`
+- source/target friction identities
+- reason category
+- attempt count
+
+## Change Control
+
+- Trigger thresholds, event contracts, or MVP split status changes require ADR update.
+- Backward compatibility impact on projections/consumers must be documented before rollout.

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ This directory is the single source of truth for shared product, domain, and arc
 - [Observation Clustering Strategy](./OBSERVATION_CLUSTERING.md)
 - [Metrics Semantics and Edge-Case Policy](./METRICS_SEMANTICS.md)
 - [Descriptor Generation Policy](./DESCRIPTOR_GENERATION.md)
+- [Merge/Split Execution Policy](./MERGE_SPLIT_POLICY.md)
 - [Repo Boundaries](./REPO_BOUNDARIES.md)
 - [Versioning Policy](./VERSIONING.md)
 - [Decision Records Index](./adr/README.md)

--- a/docs/adr/ADR-0009-merge-split-execution-policy.md
+++ b/docs/adr/ADR-0009-merge-split-execution-policy.md
@@ -1,0 +1,46 @@
+# ADR-0009 Friction Merge/Split Execution Policy
+
+- Status: Accepted
+- Date: 2026-03-08
+
+## Context
+
+Merge/split behavior was partially described but lacked explicit operational and event semantics. This created ambiguity in conflict handling, retries, and projection behavior.
+
+## Decision
+
+Adopt a canonical merge/split execution policy defined in `MERGE_SPLIT_POLICY.md`.
+
+Key decisions:
+
+- Explicit merge triggers and strict execution prerequisites.
+- Deterministic deduplication and recomputation during merge execution.
+- Idempotent merge operations keyed by operation identity and friction pair.
+- Explicit event semantics for merge success/rejection/failure.
+- Split execution disabled for MVP; only split-candidate detection events are emitted.
+- Atomic commit or compensating recovery requirements for failed merges.
+
+## Consequences
+
+- Merge behavior is now deterministic, auditable, and operationally safer.
+- Consumers can rely on explicit merge outcome events.
+- MVP avoids high-risk split mutation while retaining detection telemetry.
+- Additional operational complexity is introduced for locking/recovery paths.
+
+## Tradeoffs
+
+- Disabling split execution in MVP reduces risk but delays automated cluster correction.
+- Stricter prerequisites/conflict checks can reject borderline operations that might otherwise merge.
+
+## Constraints
+
+- No partial state mutation on rejected/conflicting operations.
+- Retried operations must remain idempotent.
+- Split completion events are not allowed during MVP mode.
+
+## References
+
+- [MERGE_SPLIT_POLICY.md](../MERGE_SPLIT_POLICY.md)
+- [OBSERVATION_CLUSTERING.md](../OBSERVATION_CLUSTERING.md)
+- [METRICS_SEMANTICS.md](../METRICS_SEMANTICS.md)
+- [friction-technical-and-conceptual-overview.md](../friction-technical-and-conceptual-overview.md)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -12,3 +12,4 @@ Architecture Decision Records (ADRs) are the primary decision log for shared Fri
 - [ADR-0006 Observation Clustering Strategy](./ADR-0006-observation-clustering-strategy.md)
 - [ADR-0007 Metrics Semantics and Edge-Case Policy](./ADR-0007-metrics-semantics-and-edge-cases.md)
 - [ADR-0008 Friction Descriptor Generation Policy](./ADR-0008-descriptor-generation-policy.md)
+- [ADR-0009 Friction Merge/Split Execution Policy](./ADR-0009-merge-split-execution-policy.md)

--- a/docs/friction-technical-and-conceptual-overview.md
+++ b/docs/friction-technical-and-conceptual-overview.md
@@ -222,7 +222,7 @@ sequenceDiagram
 
 * **Observation Clustering Logic:** Defined in `OBSERVATION_CLUSTERING.md` and governed by `ADR-0006`.
 * **Descriptor Generation:** Defined in `DESCRIPTOR_GENERATION.md` and governed by `ADR-0008`.
-* **Merge Strategy:** The behavior of `Friction.mergeWith()` is not fully defined. It must be clarified what triggers a merge—an external process, user action, or automated rule—when two frictions are duplicates.
+* **Merge Strategy:** Defined in `MERGE_SPLIT_POLICY.md` and governed by `ADR-0009`.
 * **Metrics Calculation Details:** Defined in `METRICS_SEMANTICS.md` and governed by `ADR-0007`.
 * **Security & Access Control:** Strategies for securing sensitive configuration data (`SourceConfig` may contain API keys) and controlling access to source configuration or friction data are not detailed.
 * **Scalability and Performance:** While horizontal scaling is assumed, specific strategies for data partitioning, high-volume ingestion, and efficient clustering are not defined.


### PR DESCRIPTION
- Added canonical merge/split execution spec: `docs/MERGE_SPLIT_POLICY.md`.
- Documented explicit policy for:
  - merge triggers and prerequisites
  - split triggers and MVP split status
  - conflict handling and idempotency expectations
  - event emission semantics for merge/split outcomes
  - rollback/recovery behavior for failed operations
  - observability requirements
- Added ADR: `docs/adr/ADR-0009-merge-split-execution-policy.md` with rationale, constraints, and tradeoffs.
- Updated docs indexes:
  - `docs/README.md` now links merge/split policy
  - `docs/adr/README.md` now links ADR-0009
- Updated technical overview open questions to reference merge/split policy + ADR instead of leaving merge strategy undefined.