### PR TITLE
define security/access-control policy and record ADR-0010

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ This directory is the single source of truth for shared product, domain, and arc
 - [Metrics Semantics and Edge-Case Policy](./METRICS_SEMANTICS.md)
 - [Descriptor Generation Policy](./DESCRIPTOR_GENERATION.md)
 - [Merge/Split Execution Policy](./MERGE_SPLIT_POLICY.md)
+- [Security and Access Control Policy](./SECURITY_ACCESS_CONTROL.md)
 - [Repo Boundaries](./REPO_BOUNDARIES.md)
 - [Versioning Policy](./VERSIONING.md)
 - [Decision Records Index](./adr/README.md)

--- a/docs/SECURITY_ACCESS_CONTROL.md
+++ b/docs/SECURITY_ACCESS_CONTROL.md
@@ -1,0 +1,100 @@
+# Security and Access Control Policy
+
+This document defines baseline security and access-control policy for `friction-core` contracts and operational behavior.
+
+## Scope
+
+- Applies to handling of source configuration, credentials, sensitive data access, and logging.
+- Defines minimum controls for adapters and services consuming core contracts.
+- Complements canonical event, clustering, metrics, and merge/split policies.
+
+## 1) `SourceConfig.auth` and Secret Material
+
+### Principles
+
+- Secrets are never stored in plaintext in source code, VCS, or static config files.
+- `SourceConfig.auth` must reference secure secret material (token/provider reference), not raw credentials when avoidable.
+- Secret values must be injected at runtime from approved secret stores or environment boundaries.
+
+### Handling Rules
+
+- In-memory secret lifetime should be minimized.
+- Secret values must not be echoed, serialized to logs, or included in exception messages.
+- Secret-bearing objects should be treated as sensitive and excluded from debug dumps.
+
+## 2) Access-Control Boundaries
+
+### Configuration Access
+
+- Source configuration write access is restricted to authorized operator/service principals.
+- Read access to sensitive source configuration fields must be least-privilege.
+- Non-sensitive configuration views should be provided separately from sensitive material.
+
+### Data Access
+
+- Provenance/evidence data access is role-scoped according to operational need.
+- Raw ingestion content access should be controllable independently from summary/read-model access.
+- Internal service-to-service access should use explicit service identity, not shared global credentials.
+
+## 3) Redaction and Sanitization Policy
+
+### Logs
+
+- Never log raw tokens, API keys, secrets, or auth headers.
+- Redact sensitive fields with deterministic placeholders (for example `***REDACTED***`).
+- Keep logs single-sentence and contextual without exposing secret material.
+
+### Failure Events
+
+- Failure payloads must include actionable reason category and identifiers, not secret values.
+- Error context should include operation identity/correlation IDs where available.
+- Schema validation failures should report missing/invalid field names only, not full sensitive payloads.
+
+## 4) Auditability Requirements
+
+Audit records are required for sensitive operations:
+
+- create/update/delete source configuration
+- auth/credential binding changes
+- key/credential rotation events
+- access-control policy changes
+
+Each audit record should include:
+
+- actor identity (user/service principal)
+- operation type
+- target entity identity
+- timestamp
+- outcome (`SUCCESS`/`FAILURE`) and reason category
+
+## 5) Credential Rotation Baseline
+
+Minimum baseline policy:
+
+- credentials/tokens must support periodic rotation.
+- rotation procedure must be non-destructive and support rollback window.
+- old credentials should be revoked after successful cutover.
+- rotation failures must surface explicit operational alerts.
+
+Operational expectations:
+
+- support dual-credential overlap window when provider allows.
+- test auth continuity before final revocation.
+
+## 6) Fail-Fast Security Behavior
+
+- Missing required auth material for protected source ingestion -> reject configuration/operation early.
+- Invalid/expired credentials -> fail operation with non-sensitive context and explicit reason category.
+- Unauthorized access attempts -> deny by default and emit audit record.
+
+## 7) Implementation Baseline for Adapters/Services
+
+- Use TLS for network transport where supported.
+- Validate endpoint/domain allowlists for external source integrations when practical.
+- Keep config immutable after startup unless explicit secure rebind workflow exists.
+- Ensure retries do not amplify unauthorized/invalid-auth failures.
+
+## 8) Change Control
+
+- Security policy changes require ADR update and documented rollout impact.
+- Any relaxation of redaction/access boundaries requires explicit risk acceptance.

--- a/docs/adr/ADR-0010-security-access-control-policy.md
+++ b/docs/adr/ADR-0010-security-access-control-policy.md
@@ -1,0 +1,38 @@
+# ADR-0010 Security and Access Control Policy
+
+- Status: Accepted
+- Date: 2026-03-08
+
+## Context
+
+Security and access-control guidance for credentials, data access, and log redaction was previously underdefined. This created risk for accidental secret exposure and inconsistent operational controls.
+
+## Decision
+
+Adopt a canonical security/access-control policy defined in `SECURITY_ACCESS_CONTROL.md`.
+
+Key decisions:
+
+- `SourceConfig.auth` handled as sensitive material with runtime secret injection.
+- Least-privilege boundaries for configuration and data access.
+- Mandatory redaction/sanitization for logs and failure contexts.
+- Audit records required for sensitive configuration and credential operations.
+- Baseline credential rotation requirements and fail-fast behavior for invalid/missing auth.
+
+## Consequences
+
+- Security handling is explicit and consistent across implementations.
+- Operational traceability improves via mandatory audit context.
+- Additional implementation overhead is required for redaction, audit, and rotation workflows.
+
+## Constraints
+
+- Secrets must never appear in logs/events/exceptions.
+- Unauthorized access defaults to deny with auditable outcome.
+- Security policy relaxations require explicit governance.
+
+## References
+
+- [SECURITY_ACCESS_CONTROL.md](../SECURITY_ACCESS_CONTROL.md)
+- [SPI.md](../SPI.md)
+- [friction-technical-and-conceptual-overview.md](../friction-technical-and-conceptual-overview.md)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -13,3 +13,4 @@ Architecture Decision Records (ADRs) are the primary decision log for shared Fri
 - [ADR-0007 Metrics Semantics and Edge-Case Policy](./ADR-0007-metrics-semantics-and-edge-cases.md)
 - [ADR-0008 Friction Descriptor Generation Policy](./ADR-0008-descriptor-generation-policy.md)
 - [ADR-0009 Friction Merge/Split Execution Policy](./ADR-0009-merge-split-execution-policy.md)
+- [ADR-0010 Security and Access Control Policy](./ADR-0010-security-access-control-policy.md)

--- a/docs/friction-technical-and-conceptual-overview.md
+++ b/docs/friction-technical-and-conceptual-overview.md
@@ -224,7 +224,7 @@ sequenceDiagram
 * **Descriptor Generation:** Defined in `DESCRIPTOR_GENERATION.md` and governed by `ADR-0008`.
 * **Merge Strategy:** Defined in `MERGE_SPLIT_POLICY.md` and governed by `ADR-0009`.
 * **Metrics Calculation Details:** Defined in `METRICS_SEMANTICS.md` and governed by `ADR-0007`.
-* **Security & Access Control:** Strategies for securing sensitive configuration data (`SourceConfig` may contain API keys) and controlling access to source configuration or friction data are not detailed.
+* **Security & Access Control:** Defined in `SECURITY_ACCESS_CONTROL.md` and governed by `ADR-0010`.
 * **Scalability and Performance:** While horizontal scaling is assumed, specific strategies for data partitioning, high-volume ingestion, and efficient clustering are not defined.
 
 ## 9. Recommended Java Project Structure


### PR DESCRIPTION
- Added canonical security policy spec: `docs/SECURITY_ACCESS_CONTROL.md`.
- Documented explicit policy for:
  - `SourceConfig.auth` and secret handling
  - access-control boundaries for config and data
  - log/event redaction and sanitization
  - auditability requirements for sensitive operations
  - credential rotation baseline and fail-fast security behavior
- Added ADR: `docs/adr/ADR-0010-security-access-control-policy.md` with rationale, constraints, and consequences.
- Updated canonical indexes:
  - `docs/README.md` now links security policy
  - `docs/adr/README.md` now links ADR-0010
- Updated technical overview open questions to reference security policy + ADR instead of leaving security/access control undefined.