### PR TITLE
define scalability/partitioning strategy and record ADR-0011

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ This directory is the single source of truth for shared product, domain, and arc
 - [Descriptor Generation Policy](./DESCRIPTOR_GENERATION.md)
 - [Merge/Split Execution Policy](./MERGE_SPLIT_POLICY.md)
 - [Security and Access Control Policy](./SECURITY_ACCESS_CONTROL.md)
+- [Scalability and Partitioning Strategy](./SCALABILITY_PARTITIONING.md)
 - [Repo Boundaries](./REPO_BOUNDARIES.md)
 - [Versioning Policy](./VERSIONING.md)
 - [Decision Records Index](./adr/README.md)

--- a/docs/SCALABILITY_PARTITIONING.md
+++ b/docs/SCALABILITY_PARTITIONING.md
@@ -1,0 +1,118 @@
+# Scalability and Partitioning Strategy
+
+This document defines the canonical strategy for scaling ingestion, processing, and projection updates in Friction.
+
+## Scope
+
+- Applies to high-volume ingestion and event-driven processing across source, friction, and projection paths.
+- Defines partitioning boundaries, backpressure, fan-out, replay/rebuild, and performance diagnostics.
+- Complements canonical event, clustering, metrics, merge/split, and security policies.
+
+## 1) Partition Keys and Ownership Boundaries
+
+## Partition Keys
+
+Primary partition key:
+
+- `sourceId` for ingestion-stage operations
+
+Secondary processing key:
+
+- `frictionId` for friction-update and projection-stage operations
+
+## Ownership Boundaries
+
+- Ingestion workers own `sourceId` partitions.
+- Friction update workers own `frictionId` partitions.
+- Projection workers own read-model shard partitions (by `frictionId` hash or equivalent stable shard key).
+
+Rules:
+
+- Maintain in-order handling per partition key where semantic ordering is required.
+- Cross-partition operations (for example merge) must use explicit coordination and idempotent operation keys.
+
+## 2) Ingestion Throughput and Backpressure
+
+## Throughput Strategy
+
+- Use bounded worker pools per partition class.
+- Prefer pull/poll interval controls per source rather than unbounded fan-in.
+- Apply adaptive polling where supported by source characteristics.
+
+## Backpressure Policy
+
+- Bound ingestion queue size by source partition.
+- On pressure threshold breach:
+  - slow polling rate
+  - drop/skip low-priority retries before dropping new valid data
+- Never allow unbounded buffering in memory.
+
+Failure safety:
+
+- Retry transient failures with bounded attempts and backoff.
+- Route retry-exhausted events to explicit failure path without blocking entire partition.
+
+## 3) Projection Fan-Out and Update Scaling
+
+- Projection updates are event-driven and independently scalable from write-side aggregation.
+- Use per-projection consumer groups/workers where possible (for example summary and detail projections).
+- Keep projection handlers idempotent by entity identity/version marker.
+- Isolate slow projection sinks to prevent global throughput collapse.
+
+Consistency target:
+
+- write-side aggregate updates are authoritative.
+- read-side projections are eventually consistent with bounded lag objectives.
+
+## 4) Replay/Rebuild Strategy for Read Models at Scale
+
+- Rebuild read models from durable event/log history.
+- Support full rebuild and partition-scoped rebuild modes.
+- Rebuild process requirements:
+  - deterministic event ordering per partition
+  - checkpointing for resumable progress
+  - idempotent projection writes
+
+Operational guidance:
+
+- Run rebuild in throttled mode to avoid starving live traffic.
+- Compare rebuilt projection checksums/counts against live expectations before cutover.
+
+## 5) Performance SLO Guidance and Bottleneck Diagnostics
+
+## Baseline SLO Categories
+
+Track at minimum:
+
+- ingestion latency (source pull to record accepted)
+- friction update latency (record accepted to friction updated)
+- projection lag (friction updated to read-model visible)
+- end-to-end freshness (ingestion to UI/API visibility)
+
+## Bottleneck Diagnostics
+
+Capture and monitor:
+
+- per-partition queue depth
+- worker utilization and saturation
+- retry volume and retry-exhaustion rate
+- projection lag distribution (p50/p95/p99)
+- hot-partition detection (skewed key distribution)
+
+Diagnosis actions:
+
+- rebalance partitions for hot-key skew
+- increase worker capacity for saturated stages
+- tune poll/retry/backoff settings for pressure relief
+
+## 6) Runtime Guardrails
+
+- No stage may rely on unbounded in-memory queues.
+- All retries must be bounded and classified by transient vs terminal failures.
+- Partition ownership and keying must be explicit in implementation config.
+- Cross-partition mutation operations require idempotent operation identifiers.
+
+## 7) Change Control
+
+- Partition-key or SLO policy changes require ADR update.
+- Replay/rebuild semantics changes must include compatibility impact notes for operators and projection consumers.

--- a/docs/adr/ADR-0011-scalability-partitioning-strategy.md
+++ b/docs/adr/ADR-0011-scalability-partitioning-strategy.md
@@ -1,0 +1,43 @@
+# ADR-0011 Scalability and Partitioning Strategy
+
+- Status: Accepted
+- Date: 2026-03-08
+
+## Context
+
+Scalability and partitioning guidance was previously high-level and non-operational. High-volume ingestion and projection workloads need explicit keying, backpressure, and rebuild policy to remain predictable.
+
+## Decision
+
+Adopt canonical scalability/partitioning policy in `SCALABILITY_PARTITIONING.md`.
+
+Key decisions:
+
+- partition ingestion by `sourceId` and friction/projection processing by `frictionId`
+- enforce bounded queues and explicit backpressure controls
+- scale projections independently with idempotent handlers
+- define deterministic, checkpointed replay/rebuild modes for read models
+- establish SLO categories and bottleneck diagnostics as operational baseline
+
+## Consequences
+
+- Horizontal scaling behavior is now explicit and auditable.
+- Operators gain concrete diagnostics and tuning controls.
+- Implementation complexity increases for partition coordination and rebuild tooling.
+
+## Tradeoffs
+
+- Strong partition ordering simplifies correctness but can reduce raw throughput on hot keys.
+- Conservative backpressure protects stability but may increase latency under bursty load.
+
+## Constraints
+
+- No unbounded buffering.
+- Retries must be bounded and classified.
+- Cross-partition operations require explicit idempotent coordination.
+
+## References
+
+- [SCALABILITY_PARTITIONING.md](../SCALABILITY_PARTITIONING.md)
+- [friction-event-driven-architecture.md](../friction-event-driven-architecture.md)
+- [friction-technical-and-conceptual-overview.md](../friction-technical-and-conceptual-overview.md)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -14,3 +14,4 @@ Architecture Decision Records (ADRs) are the primary decision log for shared Fri
 - [ADR-0008 Friction Descriptor Generation Policy](./ADR-0008-descriptor-generation-policy.md)
 - [ADR-0009 Friction Merge/Split Execution Policy](./ADR-0009-merge-split-execution-policy.md)
 - [ADR-0010 Security and Access Control Policy](./ADR-0010-security-access-control-policy.md)
+- [ADR-0011 Scalability and Partitioning Strategy](./ADR-0011-scalability-partitioning-strategy.md)

--- a/docs/friction-technical-and-conceptual-overview.md
+++ b/docs/friction-technical-and-conceptual-overview.md
@@ -225,7 +225,7 @@ sequenceDiagram
 * **Merge Strategy:** Defined in `MERGE_SPLIT_POLICY.md` and governed by `ADR-0009`.
 * **Metrics Calculation Details:** Defined in `METRICS_SEMANTICS.md` and governed by `ADR-0007`.
 * **Security & Access Control:** Defined in `SECURITY_ACCESS_CONTROL.md` and governed by `ADR-0010`.
-* **Scalability and Performance:** While horizontal scaling is assumed, specific strategies for data partitioning, high-volume ingestion, and efficient clustering are not defined.
+* **Scalability and Performance:** Defined in `SCALABILITY_PARTITIONING.md` and governed by `ADR-0011`.
 
 ## 9. Recommended Java Project Structure
 


### PR DESCRIPTION
- Added canonical scaling spec: `docs/SCALABILITY_PARTITIONING.md`.
- Documented explicit policy for:
  - partition keys and ownership boundaries
  - ingestion throughput and backpressure strategy
  - projection fan-out/update scaling
  - replay/rebuild strategy for read models at scale
  - performance SLO guidance and bottleneck diagnostics
  - runtime guardrails for bounded buffering/retries
- Added ADR: `docs/adr/ADR-0011-scalability-partitioning-strategy.md` with rationale, constraints, and tradeoffs.
- Updated canonical indexes:
  - `docs/README.md` now links scalability/partitioning strategy
  - `docs/adr/README.md` now links ADR-0011
- Updated technical overview open questions to reference scalability strategy + ADR instead of leaving scalability undefined.