### PR TITLE
add local GitHub Actions preflight script and workflow dev guide

### DIFF
--- a/docs/WORKFLOW_DEV.md
+++ b/docs/WORKFLOW_DEV.md
@@ -1,0 +1,57 @@
+# Workflow Development and Local Preflight
+
+Use this guide to validate GitHub Actions workflows locally before pushing.
+
+## Required Tools
+
+- `actionlint`
+- `yamllint`
+- `act`
+
+## Installation
+
+### Arch Linux (`pacman`)
+
+```bash
+sudo pacman -S --needed actionlint yamllint act
+```
+
+### actionlint
+
+- Project: `https://github.com/rhysd/actionlint`
+- Example (Go): `go install github.com/rhysd/actionlint/cmd/actionlint@latest`
+
+### yamllint
+
+- Example (pipx): `pipx install yamllint`
+- Alternative: `pip install yamllint`
+
+### act
+
+- Project: `https://github.com/nektos/act`
+- Install using package manager or official release binary
+
+## Run Local Preflight
+
+From repo root:
+
+```bash
+scripts/check-workflows.sh
+```
+
+What it does:
+
+1. Verifies required tools are installed.
+2. Runs `actionlint`.
+3. Runs `yamllint .github/workflows`.
+4. Runs `act` dry-run smoke checks for key workflows if present:
+   - `ci.yml`
+   - `release.yml`
+   - `publish.yml`
+
+## Notes
+
+- The script is non-destructive and fast-fails on first error.
+- If `.github/workflows` does not exist yet, the script exits successfully with a skip message.
+- `act` dry-run validates workflow wiring without full execution.
+- Before merge, still run a real GitHub-hosted workflow execution for runner parity.

--- a/scripts/check-workflows.sh
+++ b/scripts/check-workflows.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+WORKFLOW_DIR="$ROOT_DIR/.github/workflows"
+
+require_cmd() {
+  local cmd="$1"
+  local install_hint="$2"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "ERROR: Missing required command: $cmd"
+    echo "Install hint: $install_hint"
+    exit 1
+  fi
+}
+
+print_step() {
+  echo
+  echo "==> $1"
+}
+
+print_step "Validating local tooling"
+require_cmd "actionlint" "https://github.com/rhysd/actionlint"
+require_cmd "yamllint" "pipx install yamllint (or pip install yamllint)"
+require_cmd "act" "https://github.com/nektos/act"
+
+if [[ ! -d "$WORKFLOW_DIR" ]]; then
+  echo "No workflow directory found at $WORKFLOW_DIR"
+  echo "Nothing to validate yet"
+  exit 0
+fi
+
+print_step "Running actionlint"
+(
+  cd "$ROOT_DIR"
+  actionlint
+)
+
+print_step "Running yamllint on workflow files"
+(
+  cd "$ROOT_DIR"
+  yamllint .github/workflows
+)
+
+print_step "Running act dry-run smoke checks for key workflows"
+KEY_WORKFLOWS=("ci.yml" "release.yml" "publish.yml")
+FOUND=0
+
+for wf in "${KEY_WORKFLOWS[@]}"; do
+  full_path="$WORKFLOW_DIR/$wf"
+  if [[ -f "$full_path" ]]; then
+    FOUND=1
+    echo "Dry-run: $wf"
+    (
+      cd "$ROOT_DIR"
+      act -n pull_request -W ".github/workflows/$wf"
+    )
+  fi
+done
+
+if [[ "$FOUND" -eq 0 ]]; then
+  echo "No key workflows found (${KEY_WORKFLOWS[*]}); skipping act smoke checks"
+fi
+
+echo
+echo "Workflow preflight checks passed"


### PR DESCRIPTION
- Added local workflow preflight script: `scripts/check-workflows.sh`.
- Script validates local workflow quality by running:
  - `actionlint`
  - `yamllint .github/workflows`
  - `act` dry-run smoke checks for key workflows if present (`ci.yml`, `release.yml`, `publish.yml`)
- Script is non-destructive, fast-fail, and handles missing workflow directory gracefully.
- Added developer guide: `docs/WORKFLOW_DEV.md` with install and usage instructions for:
  - `actionlint`
  - `yamllint`
  - `act`
- Included Arch Linux installation via `pacman` for all three tools.