### PR TITLE
implement phase 1 PR CI and version-label validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,99 @@
+---
+name: CI
+
+'on':
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+      - labeled
+      - unlabeled
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-test:
+    name: build-and-test
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '25'
+          cache: maven
+
+      - name: Build and test
+        run: mvn -B -ntp verify
+
+  version-label-check:
+    name: version-label-check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate version labels on PR
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          labels_json="$(
+            jq -c '[.pull_request.labels[].name]' "$GITHUB_EVENT_PATH"
+          )"
+          echo "PR labels: $labels_json"
+
+          has_major="$(
+            jq -r 'index("version:major") != null' <<< "$labels_json"
+          )"
+          has_minor="$(
+            jq -r 'index("version:minor") != null' <<< "$labels_json"
+          )"
+          has_patch="$(
+            jq -r 'index("version:patch") != null' <<< "$labels_json"
+          )"
+
+          has_alpha="$(
+            jq -r 'index("version:alpha") != null' <<< "$labels_json"
+          )"
+          has_beta="$(
+            jq -r 'index("version:beta") != null' <<< "$labels_json"
+          )"
+          has_rc="$(
+            jq -r 'index("version:rc") != null' <<< "$labels_json"
+          )"
+
+          impact_count=0
+          prerelease_count=0
+
+          [[ "$has_major" == "true" ]] && impact_count=$((impact_count + 1))
+          [[ "$has_minor" == "true" ]] && impact_count=$((impact_count + 1))
+          [[ "$has_patch" == "true" ]] && impact_count=$((impact_count + 1))
+
+          if [[ "$has_alpha" == "true" ]]; then
+            prerelease_count=$((prerelease_count + 1))
+          fi
+          if [[ "$has_beta" == "true" ]]; then
+            prerelease_count=$((prerelease_count + 1))
+          fi
+          if [[ "$has_rc" == "true" ]]; then
+            prerelease_count=$((prerelease_count + 1))
+          fi
+
+          if [[ "$impact_count" -ne 1 ]]; then
+            echo "Expected exactly one impact label:"
+            echo "version:major | version:minor | version:patch"
+            exit 1
+          fi
+
+          if [[ "$prerelease_count" -gt 1 ]]; then
+            echo "Expected at most one prerelease label:"
+            echo "version:alpha | version:beta | version:rc"
+            exit 1
+          fi
+
+          echo "Version label policy check passed"

--- a/docs/WORKFLOW_DEV.md
+++ b/docs/WORKFLOW_DEV.md
@@ -49,6 +49,26 @@ What it does:
    - `release.yml`
    - `publish.yml`
 
+## PR Checks and Label Policy
+
+`friction-core` PR validation is defined in `.github/workflows/ci.yml` and exposes these stable check names:
+
+- `build-and-test`
+- `version-label-check`
+
+Branch protection should require both checks.
+
+Version labels enforced by `version-label-check`:
+
+- Exactly one impact label is required:
+  - `version:major`
+  - `version:minor`
+  - `version:patch`
+- At most one pre-release label is allowed:
+  - `version:alpha`
+  - `version:beta`
+  - `version:rc`
+
 ## Notes
 
 - The script is non-destructive and fast-fails on first error.


### PR DESCRIPTION
Implements CI/CD Phase 1 in `friction-core` by introducing PR build/test checks and strict version-label validation.

### Changes
- Added `CI` workflow for PR events in `.github/workflows/ci.yml`.
- Added `build-and-test` job running `mvn -B -ntp verify`.
- Added `version-label-check` job enforcing:
  - exactly one of `version:major|version:minor|version:patch`
  - at most one of `version:alpha|version:beta|version:rc`
- Updated `docs/WORKFLOW_DEV.md` with required check names and label expectations.

### Validation
- Local Maven build/test passed.
- `actionlint` passed.
- `yamllint .github/workflows` passed.
- `act` smoke run remains environment-dependent (Docker access required).

### Branch protection checks to require
- `build-and-test`
- `version-label-check`