### PR TITLE
implement phase 2 release automation and GitHub Packages publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,17 @@ jobs:
       - name: Build and test
         run: mvn -B -ntp verify
 
+      - name: Upload CI debug reports
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ci-debug-reports
+          path: |
+            target/surefire-reports/**
+            target/failsafe-reports/**
+          if-no-files-found: ignore
+          retention-days: 1
+
   version-label-check:
     name: version-label-check
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,53 @@
+---
+name: Publish Package
+
+'on':
+  release:
+    types:
+      - published
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    name: publish
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '25'
+          cache: maven
+          server-id: github
+          settings-path: ${{ github.workspace }}
+
+      - name: Set release version
+        run: |
+          set -euo pipefail
+          tag="${GITHUB_REF_NAME}"
+          version="${tag#v}"
+          mvn -B -ntp versions:set \
+            -DnewVersion="${version}" \
+            -DgenerateBackupPoms=false
+
+      - name: Publish Maven package to GitHub Packages
+        env:
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          repo_url="https://maven.pkg.github.com/${{ github.repository }}"
+          deploy_repo="github::default::${repo_url}"
+          mvn -B -ntp deploy \
+            -DskipTests \
+            -DaltDeploymentRepository="${deploy_repo}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,213 @@
+---
+name: Release
+
+'on':
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: write
+  pull-requests: read
+
+concurrency:
+  group: release-master
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: release
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve PR labels and compute next version
+        id: version
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const sha = context.sha;
+
+            const prResp = await github.rest.repos
+              .listPullRequestsAssociatedWithCommit({
+                owner,
+                repo,
+                commit_sha: sha,
+              });
+
+            if (!prResp.data.length) {
+              core.setFailed(
+                `No pull request associated with commit ${sha}.`
+              );
+              return;
+            }
+
+            const mergedPr = prResp.data.find((item) => item.merged_at);
+            const pr = mergedPr || prResp.data[0];
+            const labels = pr.labels.map((label) => label.name);
+
+            const impactLabels = [
+              "version:major",
+              "version:minor",
+              "version:patch",
+            ];
+            const preLabels = [
+              "version:alpha",
+              "version:beta",
+              "version:rc",
+            ];
+
+            const impact = impactLabels.filter(
+              (label) => labels.includes(label)
+            );
+            const prerelease = preLabels.filter(
+              (label) => labels.includes(label)
+            );
+
+            if (impact.length !== 1) {
+              core.setFailed(
+                "Expected exactly one impact label: " +
+                impactLabels.join(", ")
+              );
+              return;
+            }
+
+            if (prerelease.length > 1) {
+              core.setFailed(
+                "Expected at most one prerelease label: " +
+                preLabels.join(", ")
+              );
+              return;
+            }
+
+            const tagResp = await github.rest.repos.listTags({
+              owner,
+              repo,
+              per_page: 100,
+            });
+
+            const semverTag = /^v(\d+)\.(\d+)\.(\d+)$/;
+            const stableTags = tagResp.data
+              .map((tag) => tag.name)
+              .filter((name) => semverTag.test(name));
+
+            const previousTag = stableTags[0] || "v0.0.0";
+            const previousTagExists = stableTags.length > 0;
+
+            const match = previousTag.match(semverTag);
+            if (!match) {
+              core.setFailed(`Unable to parse previous tag ${previousTag}.`);
+              return;
+            }
+
+            let major = Number(match[1]);
+            let minor = Number(match[2]);
+            let patch = Number(match[3]);
+
+            if (impact[0] === "version:major") {
+              major += 1;
+              minor = 0;
+              patch = 0;
+            } else if (impact[0] === "version:minor") {
+              minor += 1;
+              patch = 0;
+            } else {
+              patch += 1;
+            }
+
+            let nextVersion = `${major}.${minor}.${patch}`;
+            if (prerelease.length === 1) {
+              const stage = prerelease[0].split(":")[1];
+              nextVersion = `${nextVersion}-${stage}.1`;
+            }
+
+            const nextTag = `v${nextVersion}`;
+
+            core.info(`PR #${pr.number} labels: ${labels.join(", ")}`);
+            core.info(`Previous stable tag: ${previousTag}`);
+            core.info(`Next tag: ${nextTag}`);
+
+            core.setOutput("pr_number", String(pr.number));
+            core.setOutput("pr_title", pr.title);
+            core.setOutput("previous_tag", previousTag);
+            core.setOutput("previous_tag_exists", String(previousTagExists));
+            core.setOutput("next_version", nextVersion);
+            core.setOutput("next_tag", nextTag);
+            core.setOutput("prerelease", String(prerelease.length === 1));
+
+      - name: Generate release changelog
+        id: changelog
+        uses: actions/github-script@v7
+        env:
+          PREVIOUS_TAG: ${{ steps.version.outputs.previous_tag }}
+          PREVIOUS_TAG_EXISTS: ${{ steps.version.outputs.previous_tag_exists }}
+          PR_NUMBER: ${{ steps.version.outputs.pr_number }}
+          PR_TITLE: ${{ steps.version.outputs.pr_title }}
+          NEXT_TAG: ${{ steps.version.outputs.next_tag }}
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const sha = context.sha;
+            const previousTag = process.env.PREVIOUS_TAG;
+            const previousTagExists = (
+              process.env.PREVIOUS_TAG_EXISTS === "true"
+            );
+            const prNumber = process.env.PR_NUMBER;
+            const prTitle = process.env.PR_TITLE;
+            const nextTag = process.env.NEXT_TAG;
+
+            let commits = [];
+
+            if (previousTagExists) {
+              const compare = await github.rest.repos.compareCommits({
+                owner,
+                repo,
+                basehead: `${previousTag}...${sha}`,
+              });
+              commits = compare.data.commits || [];
+            } else {
+              const commitList = await github.rest.repos.listCommits({
+                owner,
+                repo,
+                sha,
+                per_page: 20,
+              });
+              commits = commitList.data || [];
+            }
+
+            const lines = [];
+            lines.push(`# ${nextTag}`);
+            lines.push("");
+            lines.push("## Merged Pull Request");
+            lines.push(`- #${prNumber} ${prTitle}`);
+            lines.push("");
+            lines.push("## Commits");
+
+            for (const commit of commits) {
+              const shaShort = commit.sha.substring(0, 7);
+              const firstLine = commit.commit.message.split("\n")[0];
+              lines.push(`- ${shaShort} ${firstLine}`);
+            }
+
+            if (commits.length === 0) {
+              lines.push("- No commits found for changelog window.");
+            }
+
+            core.setOutput("body", lines.join("\n"));
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.version.outputs.next_tag }}
+          name: ${{ steps.version.outputs.next_tag }}
+          body: ${{ steps.changelog.outputs.body }}
+          target_commitish: ${{ github.sha }}
+          prerelease: ${{ steps.version.outputs.prerelease }}

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -1,6 +1,6 @@
 # Versioning Policy (Label-Driven)
 
-Releases are guided by GitHub labels that indicate semantic impact.
+Releases are guided by PR labels and automated on merge to `master`.
 
 ## Labels
 
@@ -15,14 +15,42 @@ Releases are guided by GitHub labels that indicate semantic impact.
 
 ## Rules
 
-- A release must be tagged with **exactly one** of `major`, `minor`, `patch`.
-- Pre-release labels (`alpha`, `beta`, `rc`) can be combined with a main label.
-- If multiple impact labels appear, **highest impact wins** (`major > minor > patch`).
-- Pre-releases should advance by stage: `alpha → beta → rc → stable`.
+- A merged PR must include **exactly one** impact label:
+  - `version:major` or `version:minor` or `version:patch`
+- A merged PR may include **at most one** pre-release label:
+  - `version:alpha` or `version:beta` or `version:rc`
+- Missing or conflicting impact labels fail validation.
+- Merge to `master` computes the next tag from the latest stable `vX.Y.Z`.
+- If a pre-release label is present, release tag suffix is appended as:
+  - `-alpha.1`, `-beta.1`, or `-rc.1`
+
+## Release Trigger
+
+- `release.yml` runs on push to `master` (post-merge path).
+- Workflow resolves the merged PR associated with the merge commit, reads labels, computes the next version, creates tag, and creates GitHub Release.
+
+## Changelog Source
+
+- Release notes are generated automatically in `release.yml`.
+- Commit window:
+  - from latest stable tag to current merge commit
+  - or recent commit window when no prior stable tag exists
+- Release notes include:
+  - merged PR reference (`#<number> <title>`)
+  - commit list (`<sha7> <summary>`)
+
+## Publishing
+
+- `publish.yml` runs on `release.published`.
+- Publishes `friction-core` Maven artifact to GitHub Packages using `GITHUB_TOKEN`.
+
+## Workflow Permissions
+
+- `release.yml`: `contents: write`, `pull-requests: read`
+- `publish.yml`: `contents: read`, `packages: write`
 
 ## Examples
 
 - `version:minor + version:beta` → `v0.4.0-beta.1`
 - `version:patch` → `v0.4.1`
 - `version:major + version:rc` → `v1.0.0-rc.1`
-

--- a/docs/WORKFLOW_DEV.md
+++ b/docs/WORKFLOW_DEV.md
@@ -49,6 +49,21 @@ What it does:
    - `release.yml`
    - `publish.yml`
 
+## Release and Publish Workflows
+
+`friction-core` release automation workflows:
+
+- `.github/workflows/release.yml`
+  - Trigger: push to `master`
+  - Behavior: resolve merged PR labels, compute semver tag, generate changelog,
+    create GitHub Release
+  - Permissions: `contents: write`, `pull-requests: read`
+- `.github/workflows/publish.yml`
+  - Trigger: `release.published`
+  - Behavior: set Maven project version from release tag and publish to GitHub
+    Packages
+  - Permissions: `contents: read`, `packages: write`
+
 ## PR Checks and Label Policy
 
 `friction-core` PR validation is defined in `.github/workflows/ci.yml` and exposes these stable check names:
@@ -68,6 +83,15 @@ Version labels enforced by `version-label-check`:
   - `version:alpha`
   - `version:beta`
   - `version:rc`
+
+The same label constraints are enforced again during `release.yml` execution.
+
+## Artifact Retention
+
+- CI debug artifacts use explicit short retention:
+  - `ci.yml` upload step sets `retention-days: 1`
+- No long-lived workflow artifacts are retained for non-release runs.
+- Long-lived distributables are published as GitHub Releases and GitHub Packages.
 
 ## Notes
 


### PR DESCRIPTION
Adds `friction-core` Phase 2 CI/CD automation: semantic release tagging, generated release notes, and package publishing on release.

### Changes
- Added `release.yml` for merge-to-`master` semantic version release flow.
- Added `publish.yml` for GitHub Packages Maven publish on release publication.
- Added short-lived CI debug artifacts (`retention-days: 1`) in `ci.yml`.
- Updated `docs/VERSIONING.md` and `docs/WORKFLOW_DEV.md` to document trigger behavior, permissions, changelog generation, and retention policy.

### Validation
- `mvn -B -ntp verify` passed.
- `actionlint` passed.
- `yamllint .github/workflows` passed.

### Notes
- `release.yml` assumes merge commits on `master` are associated with PR metadata.
- If branch protection enforces squash/rebase patterns, PR association still depends on GitHub commit linkage.