### PR TITLE
improve release notes and package dependency layout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -204,7 +204,6 @@ jobs:
               process.env.PREVIOUS_TAG_EXISTS === "true"
             );
             const prNumber = process.env.PR_NUMBER;
-            const prTitle = process.env.PR_TITLE;
             const nextTag = process.env.NEXT_TAG;
 
             let commits = [];
@@ -226,22 +225,80 @@ jobs:
               commits = commitList.data || [];
             }
 
+            const prNumbers = new Set();
+            prNumbers.add(Number(prNumber));
+
+            for (const commit of commits) {
+              const firstLine = commit.commit.message.split("\n")[0];
+              const mergeMatch = firstLine.match(/^Merge pull request #(\d+)/);
+              if (mergeMatch) {
+                prNumbers.add(Number(mergeMatch[1]));
+              }
+              const squashMatch = firstLine.match(/\(#(\d+)\)$/);
+              if (squashMatch) {
+                prNumbers.add(Number(squashMatch[1]));
+              }
+
+              const commitPrs = await github.rest.repos
+                .listPullRequestsAssociatedWithCommit({
+                  owner,
+                  repo,
+                  commit_sha: commit.sha,
+                });
+              for (const item of commitPrs.data) {
+                if (item.merged_at) {
+                  prNumbers.add(item.number);
+                }
+              }
+            }
+
+            const mergedPrs = [];
+            const sortedPrNumbers = Array.from(prNumbers).sort(
+              (a, b) => a - b
+            );
+            for (const number of sortedPrNumbers) {
+              const prResp = await github.rest.pulls.get({
+                owner,
+                repo,
+                pull_number: number,
+              });
+              if (prResp.data.merged_at) {
+                mergedPrs.push(prResp.data);
+              }
+            }
+
+            const nonMergeCommits = commits.filter((commit) => {
+              const firstLine = commit.commit.message.split("\n")[0];
+              return !firstLine.startsWith("Merge pull request #");
+            });
+
             const lines = [];
             lines.push(`# ${nextTag}`);
             lines.push("");
-            lines.push("## Merged Pull Request");
-            lines.push(`- #${prNumber} ${prTitle}`);
+            if (previousTagExists) {
+              lines.push(`Changes since ${previousTag}.`);
+            } else {
+              lines.push("Initial release window.");
+            }
             lines.push("");
-            lines.push("## Commits");
+            lines.push("## Merged Pull Requests");
 
-            for (const commit of commits) {
-              const shaShort = commit.sha.substring(0, 7);
-              const firstLine = commit.commit.message.split("\n")[0];
-              lines.push(`- ${shaShort} ${firstLine}`);
+            if (mergedPrs.length) {
+              for (const pr of mergedPrs) {
+                lines.push(`- #${pr.number} ${pr.title}`);
+              }
+            } else {
+              lines.push("- No merged pull requests resolved for this window.");
             }
 
-            if (commits.length === 0) {
-              lines.push("- No commits found for changelog window.");
+            if (nonMergeCommits.length) {
+              lines.push("");
+              lines.push("## Direct Commits");
+              for (const commit of nonMergeCommits.slice(-20)) {
+                const shaShort = commit.sha.substring(0, 7);
+                const firstLine = commit.commit.message.split("\n")[0];
+                lines.push(`- ${shaShort} ${firstLine}`);
+              }
             }
 
             core.setOutput("body", lines.join("\n"));

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@
 
   # Logs
   *.log
+/target

--- a/README.md
+++ b/README.md
@@ -10,3 +10,9 @@
 
   ## Docs
   See [docs](docs/) full architecture and design notes.
+
+  ## Published Artifacts
+  GitHub Packages publish includes:
+  - Standard library jar: `friction-core-<version>.jar`
+  - Non-shaded runtime dependencies copied at package time to:
+    - `target/libs/*.jar`

--- a/pom.xml
+++ b/pom.xml
@@ -1,13 +1,34 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <groupId>com.github.idelstak</groupId>
-    <artifactId>friction-core</artifactId>
-    <version>0.0.0</version>
-    <packaging>jar</packaging>
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.release>25</maven.compiler.release>
-        <exec.mainClass>com.github.idelstak.friction.core.FrictionCore</exec.mainClass>
-    </properties>
+ <modelVersion>4.0.0</modelVersion>
+ <groupId>com.github.idelstak</groupId>
+ <artifactId>friction-core</artifactId>
+ <version>0.0.0</version>
+ <packaging>jar</packaging>
+ <properties>
+  <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  <maven.compiler.release>25</maven.compiler.release>
+  <exec.mainClass>com.github.idelstak.friction.core.FrictionCore</exec.mainClass>
+ </properties>
+ <build>
+  <plugins>
+   <plugin>
+    <artifactId>maven-dependency-plugin</artifactId>
+    <version>3.10.0</version>
+    <executions>
+     <execution>
+      <id>copy-runtime-dependencies</id>
+      <phase>package</phase>
+      <goals>
+       <goal>copy-dependencies</goal>
+      </goals>
+      <configuration>
+       <includeScope>runtime</includeScope>
+       <outputDirectory>${project.build.directory}/libs</outputDirectory>
+      </configuration>
+     </execution>
+    </executions>
+   </plugin>
+  </plugins>
+ </build>
 </project>


### PR DESCRIPTION
Refines `friction-core` release outputs by filtering merge-noise from changelog notes and switching packaging to a non-shaded dependency layout.

### Changes
- Changelog now prioritizes merged PR entries and omits `Merge pull request ...` noise lines.
- Added runtime dependency copy step in Maven build to produce `target/libs` during `package`.
- Updated docs to clarify artifact expectations.
- Ignored `/target` in `.gitignore`.

### Impact
- No API contract change.
- Improves release readability and packaging ergonomics for downstream consumers.