### PR TITLE
harden packages publish endpoint/auth config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -389,10 +389,14 @@ jobs:
         env:
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY_OWNER: ${{ github.repository_owner }}
+          REPOSITORY_NAME: ${{ github.event.repository.name }}
         run: |
           set -euo pipefail
-          repo_url="https://maven.pkg.github.com/${{ github.repository }}"
-          deploy_repo="github::default::${repo_url}"
+          owner_lc="${REPOSITORY_OWNER,,}"
+          repo_lc="${REPOSITORY_NAME,,}"
+          repo_url="https://maven.pkg.github.com/${owner_lc}/${repo_lc}"
+          deploy_repo="github::${repo_url}"
           mvn -B -ntp deploy \
             -DskipTests \
             -DaltDeploymentRepository="${deploy_repo}"


### PR DESCRIPTION
Fixes `friction-core` package publish failures by correcting Maven deploy repository construction in the release workflow.

### Changes
- Added explicit repository owner/name env vars in publish job.
- Lowercased owner/repo when building `maven.pkg.github.com` URL.
- Updated `altDeploymentRepository` to modern Maven syntax (`id::url`).

### Motivation
Publish job failed with `401 Unauthorized` while release tagging succeeded. This update targets endpoint/config consistency to remove auth/deploy ambiguity.

### Validation
- `actionlint` passed.
- `yamllint .github/workflows` passed.
- Ready for rerun of release workflow publish step.