### PR TITLE
Add semver release flow and gated package publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,10 +2,11 @@
 name: Publish Package
 
 'on':
-  push:
-    branches:
-      - master
-  workflow_dispatch:
+  workflow_run:
+    workflows:
+      - Release
+    types:
+      - completed
 
 permissions:
   contents: read
@@ -18,12 +19,16 @@ concurrency:
 jobs:
   publish:
     name: publish
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
     steps:
-      - name: Checkout
+      - name: Checkout master
         uses: actions/checkout@v4
+        with:
+          ref: master
+          fetch-depth: 0
 
       - name: Require PACKAGES_TOKEN
         env:
@@ -36,7 +41,42 @@ jobs:
             exit 1
           fi
 
+      - name: Resolve latest release tag
+        id: tag
+        run: |
+          set -euo pipefail
+          git fetch --tags --force
+          latest_tag="$(
+            git tag -l 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | head -n 1
+          )"
+          if [[ -z "${latest_tag}" ]]; then
+            echo "No stable semver tag found (expected vX.Y.Z)."
+            exit 1
+          fi
+          echo "tag=${latest_tag}" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout latest tag
+        run: |
+          set -euo pipefail
+          git checkout "${{ steps.tag.outputs.tag }}"
+
+      - name: Validate pom.xml matches tag
+        run: |
+          set -euo pipefail
+          tag="${{ steps.tag.outputs.tag }}"
+          tag_version="${tag#v}"
+          pom_version="$(
+            mvn -q -DforceStdout help:evaluate -Dexpression=project.version
+          )"
+          if [[ "${pom_version}" != "${tag_version}" ]]; then
+            echo "pom.xml version (${pom_version})"
+            echo "does not match tag (${tag_version})"
+            exit 1
+          fi
+
       - name: Set up JDK
+        env:
+          PACKAGES_TOKEN: ${{ secrets.PACKAGES_TOKEN }}
         uses: actions/setup-java@v4
         with:
           distribution: temurin
@@ -47,22 +87,8 @@ jobs:
           server-password: PACKAGES_TOKEN
           settings-path: ${{ github.workspace }}
 
-      - name: Set publish version
-        run: |
-          set -euo pipefail
-          base_version="$(
-            mvn -q -DforceStdout help:evaluate -Dexpression=project.version
-          )"
-          version="${base_version}-build.${GITHUB_RUN_NUMBER}"
-          echo "Publishing version: ${version}"
-          mvn -B -ntp versions:set \
-            -DnewVersion="${version}" \
-            -DgenerateBackupPoms=false
-
       - name: Publish Maven package to GitHub Packages
         env:
-          GITHUB_ACTOR: ${{ github.actor }}
-          PACKAGES_TOKEN: ${{ secrets.PACKAGES_TOKEN }}
           REPOSITORY_OWNER: ${{ github.repository_owner }}
           REPOSITORY_NAME: ${{ github.event.repository.name }}
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,283 @@
+---
+name: Release
+
+'on':
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: write
+  pull-requests: read
+
+concurrency:
+  group: release-master
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: release
+    if: github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve version bump from PR labels
+        id: version
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const sha = context.sha;
+            let pr = null;
+
+            const associated = await github.rest.repos
+              .listPullRequestsAssociatedWithCommit({
+                owner,
+                repo,
+                commit_sha: sha,
+              });
+            if (associated.data.length) {
+              const mergedPr = associated.data.find((item) => item.merged_at);
+              pr = mergedPr || associated.data[0];
+            }
+
+            if (!pr) {
+              const headMessage = context.payload.head_commit?.message || "";
+              const match = headMessage.match(/#(\d+)/);
+              if (match) {
+                const fetched = await github.rest.pulls.get({
+                  owner,
+                  repo,
+                  pull_number: Number(match[1]),
+                });
+                if (fetched.data.merged_at) {
+                  pr = fetched.data;
+                }
+              }
+            }
+
+            if (!pr) {
+              core.setFailed(`Unable to resolve merged PR for commit ${sha}.`);
+              return;
+            }
+
+            const labels = pr.labels.map((label) => label.name);
+            const impactLabels = [
+              "version:major",
+              "version:minor",
+              "version:patch",
+            ];
+            const prereleaseLabels = [
+              "version:alpha",
+              "version:beta",
+              "version:rc",
+            ];
+
+            const impact = impactLabels.filter(
+              (label) => labels.includes(label)
+            );
+            const prerelease = prereleaseLabels.filter(
+              (label) => labels.includes(label)
+            );
+
+            if (impact.length !== 1) {
+              core.setFailed(
+                "Expected exactly one impact label: " + impactLabels.join(", ")
+              );
+              return;
+            }
+            if (prerelease.length > 1) {
+              core.setFailed(
+                "Expected at most one prerelease label: " +
+                prereleaseLabels.join(", ")
+              );
+              return;
+            }
+
+            const tagResp = await github.rest.repos.listTags({
+              owner,
+              repo,
+              per_page: 100,
+            });
+            const semverTag = /^v(\d+)\.(\d+)\.(\d+)$/;
+            const stableTags = tagResp.data
+              .map((tag) => tag.name)
+              .filter((name) => semverTag.test(name));
+
+            const previousTag = stableTags[0] || "v0.0.0";
+            const previousTagExists = stableTags.length > 0;
+            const matchVersion = previousTag.match(semverTag);
+
+            let major = Number(matchVersion?.[1] || 0);
+            let minor = Number(matchVersion?.[2] || 0);
+            let patch = Number(matchVersion?.[3] || 0);
+
+            if (impact[0] === "version:major") {
+              major += 1;
+              minor = 0;
+              patch = 0;
+            } else if (impact[0] === "version:minor") {
+              minor += 1;
+              patch = 0;
+            } else {
+              patch += 1;
+            }
+
+            let nextVersion = `${major}.${minor}.${patch}`;
+            if (prerelease.length === 1) {
+              const stage = prerelease[0].split(":")[1];
+              nextVersion = `${nextVersion}-${stage}.1`;
+            }
+
+            const nextTag = `v${nextVersion}`;
+            core.info(`PR #${pr.number} labels: ${labels.join(", ")}`);
+            core.info(`Previous tag: ${previousTag}`);
+            core.info(`Next version: ${nextVersion}`);
+
+            core.setOutput("pr_number", String(pr.number));
+            core.setOutput("pr_title", pr.title);
+            core.setOutput("previous_tag", previousTag);
+            core.setOutput("previous_tag_exists", String(previousTagExists));
+            core.setOutput("next_version", nextVersion);
+            core.setOutput("next_tag", nextTag);
+            core.setOutput("prerelease", String(prerelease.length === 1));
+
+      - name: Set release version in pom.xml
+        run: |
+          set -euo pipefail
+          mvn -B -ntp versions:set \
+            -DnewVersion="${{ steps.version.outputs.next_version }}" \
+            -DgenerateBackupPoms=false
+
+      - name: Commit version bump
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email \
+            "41898282+github-actions[bot]@users.noreply.github.com"
+          git add pom.xml
+          next_version="${{ steps.version.outputs.next_version }}"
+          commit_msg="chore: bump version to ${next_version}"
+          git commit -m "${commit_msg}" || {
+            echo "No version change to commit"
+            exit 0
+          }
+          git push origin HEAD:master
+
+      - name: Create and push tag
+        run: |
+          set -euo pipefail
+          tag="${{ steps.version.outputs.next_tag }}"
+          if git rev-parse "$tag" >/dev/null 2>&1; then
+            echo "Tag $tag already exists; skipping"
+            exit 0
+          fi
+          git tag "$tag"
+          git push origin "$tag"
+
+      - name: Generate changelog
+        id: changelog
+        uses: actions/github-script@v7
+        env:
+          PREVIOUS_TAG: ${{ steps.version.outputs.previous_tag }}
+          PREVIOUS_TAG_EXISTS: ${{ steps.version.outputs.previous_tag_exists }}
+          PR_NUMBER: ${{ steps.version.outputs.pr_number }}
+          NEXT_TAG: ${{ steps.version.outputs.next_tag }}
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const sha = context.sha;
+            const previousTag = process.env.PREVIOUS_TAG;
+            const previousTagExists = (
+              process.env.PREVIOUS_TAG_EXISTS === "true"
+            );
+            const prNumber = process.env.PR_NUMBER;
+            const nextTag = process.env.NEXT_TAG;
+
+            let commits = [];
+            if (previousTagExists) {
+              try {
+                const compare = await github.rest.repos.compareCommits({
+                  owner,
+                  repo,
+                  basehead: `${previousTag}...${sha}`,
+                });
+                commits = compare.data.commits || [];
+              } catch (error) {
+                core.warning(`Compare failed: ${error.message}`);
+                const commitList = await github.rest.repos.listCommits({
+                  owner,
+                  repo,
+                  sha,
+                  per_page: 50,
+                });
+                commits = commitList.data || [];
+              }
+            } else {
+              const commitList = await github.rest.repos.listCommits({
+                owner,
+                repo,
+                sha,
+                per_page: 20,
+              });
+              commits = commitList.data || [];
+            }
+
+            const prNumbers = new Set([Number(prNumber)]);
+            for (const commit of commits) {
+              const firstLine = commit.commit.message.split("\n")[0];
+              const mergeMatch = firstLine.match(/^Merge pull request #(\d+)/);
+              if (mergeMatch) {
+                prNumbers.add(Number(mergeMatch[1]));
+              }
+            }
+
+            const mergedPrs = [];
+            for (const number of Array.from(prNumbers).sort((a, b) => a - b)) {
+              const prResp = await github.rest.pulls.get({
+                owner,
+                repo,
+                pull_number: number,
+              });
+              if (prResp.data.merged_at) {
+                mergedPrs.push(prResp.data);
+              }
+            }
+
+            const lines = [];
+            lines.push(`# ${nextTag}`);
+            lines.push("");
+            if (previousTagExists) {
+              lines.push(`Changes since ${previousTag}.`);
+            } else {
+              lines.push("Initial release window.");
+            }
+            lines.push("");
+            lines.push("## Merged Pull Requests");
+
+            if (mergedPrs.length) {
+              for (const pr of mergedPrs) {
+                lines.push(`- #${pr.number} ${pr.title}`);
+              }
+            } else {
+              lines.push("- No merged pull requests resolved for this window.");
+            }
+
+            core.setOutput("body", lines.join("\n"));
+
+      - name: Create GitHub Release notes
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.version.outputs.next_tag }}
+          name: ${{ steps.version.outputs.next_tag }}
+          body: ${{ steps.changelog.outputs.body }}
+          target_commitish: master
+          prerelease: ${{ steps.version.outputs.prerelease }}

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -1,34 +1,50 @@
-# Package Versioning Policy
+# Versioning Policy (Release + Publish)
 
-`friction-core` is currently configured for package publishing only (no release workflow).
+`friction-core` versioning is driven by PR labels and applied by `release.yml`.
 
-## Publish Trigger
+## Labels
 
-- `.github/workflows/publish.yml` runs on push to `master`.
-- `workflow_dispatch` is enabled for manual reruns.
+| Label | Meaning | Impact |
+| --- | --- | --- |
+| `version:major` | Breaking change | MAJOR bump |
+| `version:minor` | Backward-compatible feature | MINOR bump |
+| `version:patch` | Bugfix / refactor | PATCH bump |
+| `version:alpha` | Alpha pre-release | Pre-release |
+| `version:beta` | Beta pre-release | Pre-release |
+| `version:rc` | Release candidate | Pre-release |
 
-## Version Strategy
+## Rules
 
-- The workflow reads the base project version from `pom.xml`.
-- Published package version is derived as:
-  - `<baseVersion>-build.<GITHUB_RUN_NUMBER>`
-- This guarantees unique versions per publish run and avoids redeploy conflicts.
+- A merged PR must include exactly one impact label:
+  - `version:major` or `version:minor` or `version:patch`
+- A merged PR may include at most one pre-release label:
+  - `version:alpha` or `version:beta` or `version:rc`
+- Missing/conflicting labels fail CI.
 
-## Authentication
+## Release Version Computation
 
-- Publishing uses repository secret `PACKAGES_TOKEN` (PAT).
-- Required scopes:
-  - `write:packages`
-  - `read:packages`
-  - `repo` for private repositories
+- `release.yml` reads latest stable tag `vX.Y.Z`.
+- Computes next version from impact label:
+  - `major` -> `X+1.0.0`
+  - `minor` -> `X.Y+1.0`
+  - `patch` -> `X.Y.Z+1`
+- If pre-release label is present, appends `-alpha.1` / `-beta.1` / `-rc.1`.
 
-## Registry Target
+## pom.xml Version Updates
 
-- Packages are deployed to GitHub Maven registry:
-  - `https://maven.pkg.github.com/<owner>/<repo>`
-- Workflow normalizes owner/repo names to lowercase before deploy URL assembly.
+- `release.yml` sets `<version>` in `pom.xml` to computed next version.
+- Commits version bump to `master`.
+- Creates matching git tag `v<version>`.
 
-## Notes
+## Changelog Notes
 
-- PR version labels remain enforced by CI policy (`version:*`) as merge discipline.
-- Release tags and GitHub Release notes are not part of this publishing mode.
+- `release.yml` generates human-readable notes focused on merged PR entries.
+- Notes are attached to the tag release metadata.
+- Merge-noise commit lines are excluded from main entries.
+
+## Publishing
+
+- `publish.yml` runs on successful `workflow_run` completion of `Release`.
+- It checks out latest semver tag and verifies:
+  - `pom.xml` version == tag version
+- Publishes Maven package to GitHub Packages using `PACKAGES_TOKEN`.

--- a/docs/WORKFLOW_DEV.md
+++ b/docs/WORKFLOW_DEV.md
@@ -46,17 +46,31 @@ What it does:
 3. Runs `yamllint .github/workflows`.
 4. Runs `act` dry-run smoke checks for key workflows if present:
    - `ci.yml`
+   - `release.yml`
    - `publish.yml`
 
-## Publish Workflow
+## Workflow Partitioning
 
-`friction-core` package publishing workflow:
+`friction-core` CI/CD uses three workflows:
 
-- `.github/workflows/publish.yml`
+- `.github/workflows/ci.yml`
+  - Trigger: pull requests
+  - Behavior: build/test validation + label policy checks
+- `.github/workflows/release.yml`
   - Trigger: push to `master`
-  - Behavior: build and publish Maven package to GitHub Packages
-  - Authentication: `PACKAGES_TOKEN` repository secret (PAT)
-  - Permissions: `contents: read`, `packages: write`
+  - Behavior: resolve semantic bump from PR labels, update `pom.xml`, commit version bump, create tag, generate changelog notes
+- `.github/workflows/publish.yml`
+  - Trigger: `workflow_run` for `Release` completion
+  - Behavior: checkout latest tag, verify `pom.xml` version matches tag, publish Maven package
+
+## Authentication and Permissions
+
+- `release.yml` uses `GITHUB_TOKEN` for commit/tag/release-note operations.
+- `publish.yml` uses `PACKAGES_TOKEN` (PAT) for Maven package deployment.
+- Recommended `PACKAGES_TOKEN` scopes:
+  - `write:packages`
+  - `read:packages`
+  - `repo` (private repos)
 
 ## PR Checks and Label Policy
 
@@ -85,13 +99,6 @@ Version labels enforced by `version-label-check`:
 - No long-lived workflow artifacts are retained for non-release runs.
 - Long-lived distributables are published to GitHub Packages.
 
-## Notes
-
-- The script is non-destructive and fast-fails on first error.
-- If `.github/workflows` does not exist yet, the script exits successfully with a skip message.
-- `act` dry-run validates workflow wiring without full execution.
-- Before merge, still run a real GitHub-hosted workflow execution for runner parity.
-
 ## Troubleshooting
 
 Symptom:
@@ -104,6 +111,6 @@ Cause:
 
 Resolution:
 
-- Ensure repo secret `PACKAGES_TOKEN` exists and has `write:packages`.
-- For private repos, include `repo` scope as well.
+- Ensure repo secret `PACKAGES_TOKEN` exists and has required scopes.
 - Confirm package/repository access settings allow this repo to publish.
+- Ensure `publish.yml` runs after successful `Release` workflow completion.

--- a/scripts/check-workflows.sh
+++ b/scripts/check-workflows.sh
@@ -43,7 +43,7 @@ print_step "Running yamllint on workflow files"
 )
 
 print_step "Running act dry-run smoke checks for key workflows"
-KEY_WORKFLOWS=("ci.yml" "publish.yml")
+KEY_WORKFLOWS=("ci.yml" "release.yml" "publish.yml")
 FOUND=0
 
 for wf in "${KEY_WORKFLOWS[@]}"; do


### PR DESCRIPTION
Introduces a final 3-workflow CI/CD partitioning for `friction-core`:
- PR CI checks,
- release/versioning workflow,
- workflow-run-triggered package publish.

### Changes
- Added `release.yml` for semantic version bump, `pom.xml` update, tag creation, and changelog notes.
- Switched `publish.yml` to run only after successful `Release` workflow completion.
- Added tag/pom version consistency verification before publish.
- Kept package publishing on `PACKAGES_TOKEN`.
- Updated workflow/versioning docs and preflight script.

### Why
This model is deterministic, easier to reason about, and keeps release metadata generation separate from package deployment while preserving proper gating.

### Validation
- `actionlint` passed.
- `yamllint .github/workflows` passed.