### PR TITLE
Harden friction-core package publishing configuration

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -76,6 +76,7 @@ jobs:
 
       - name: Set up JDK
         env:
+          GITHUB_ACTOR: ${{ github.actor }}
           PACKAGES_TOKEN: ${{ secrets.PACKAGES_TOKEN }}
         uses: actions/setup-java@v4
         with:
@@ -89,14 +90,8 @@ jobs:
 
       - name: Publish Maven package to GitHub Packages
         env:
-          REPOSITORY_OWNER: ${{ github.repository_owner }}
-          REPOSITORY_NAME: ${{ github.event.repository.name }}
+          GITHUB_ACTOR: ${{ github.actor }}
+          PACKAGES_TOKEN: ${{ secrets.PACKAGES_TOKEN }}
         run: |
           set -euo pipefail
-          owner_lc="${REPOSITORY_OWNER,,}"
-          repo_lc="${REPOSITORY_NAME,,}"
-          repo_url="https://maven.pkg.github.com/${owner_lc}/${repo_lc}"
-          deploy_repo="github::${repo_url}"
-          mvn -B -ntp deploy \
-            -DskipTests \
-            -DaltDeploymentRepository="${deploy_repo}"
+          mvn -B -ntp deploy -DskipTests

--- a/docs/CI_CD_APPROACH_REPORT.md
+++ b/docs/CI_CD_APPROACH_REPORT.md
@@ -1,0 +1,173 @@
+# Friction CI/CD Approach Report
+
+## Purpose
+
+Define an agreed CI/CD model for `friction-core`, `friction-adapters`, and `friction-ui` that enforces quality gates before merge, label-driven semantic versioning, and automated publishing.
+
+## Repos in Scope
+
+- `friction-core`
+- `friction-adapters`
+- `friction-ui`
+
+## Operational Runbooks
+
+- `PUBLISH_RUNBOOK.md` - exact setup and troubleshooting steps for
+  `friction-core` release/publish pipeline and GitHub Packages auth.
+
+## Agreed Objectives
+
+1. PRs must pass automated checks before merge.
+2. Versioning must follow label-driven semantic policy (`version:*`).
+3. `friction-core` and `friction-adapters` publish as GitHub Packages.
+4. `friction-ui` publishes cross-platform release artifacts via `jpackage`.
+
+## CI Policy (Pull Requests)
+
+Trigger: `pull_request`
+
+Required checks:
+
+- Build success
+- Test suite success
+- Lint/format/static checks (as configured per repo)
+- Version label validation check
+
+Version label validation rules:
+
+- Exactly one required: `version:major` or `version:minor` or `version:patch`
+- Optional pre-release stage: `version:alpha` or `version:beta` or `version:rc`
+- PR fails if impact labels are missing or conflicting
+
+## Release and Versioning Policy
+
+Trigger: merge to default branch after required checks pass
+
+Release flow:
+
+1. Read labels from merged PR.
+2. Compute next version from latest `vX.Y.Z` tag:
+   - `version:major` -> bump major
+   - `version:minor` -> bump minor
+   - `version:patch` -> bump patch
+3. Apply optional pre-release suffix when present (`alpha`, `beta`, `rc`).
+4. Create git tag and GitHub Release.
+
+Source of truth for released versions:
+
+- Git tags and GitHub Releases
+
+## Publishing Strategy
+
+## `friction-core`
+
+- Build/package with Maven
+- Publish artifact to GitHub Packages (Maven registry)
+- Publish only on release workflow success
+
+## `friction-adapters`
+
+- Build/package with Maven
+- Publish artifact to GitHub Packages (Maven registry)
+- Publish only on release workflow success
+
+## `friction-ui`
+
+- Build JavaFX app
+- Package with `jpackage` on matrix runners:
+  - `ubuntu-latest`
+  - `windows-latest`
+  - `macos-latest`
+- Attach platform artifacts to GitHub Release
+
+## Artifact Storage and Retention Policy
+
+Objective: minimize GitHub artifact storage usage and avoid quota exhaustion.
+
+Policy:
+
+- Keep CI workflow artifacts short-lived (recommended: 1-3 days for PR runs).
+- Keep non-release build artifacts ephemeral; do not retain beyond debugging window.
+- Reserve longer retention only for release artifacts attached to GitHub Releases.
+- Avoid uploading duplicate artifacts across jobs; publish once from final packaging job.
+- Prefer selective upload (only required binaries/log bundles), not entire workspaces.
+
+Implementation guidance:
+
+- Set explicit `retention-days` on all `actions/upload-artifact` steps.
+- Use lower retention on high-frequency workflows (PRs, push validation).
+- Use scheduled cleanup checks/reporting to monitor artifact usage trends.
+
+## GitHub Actions Workflow Set
+
+Each repo should have:
+
+- `ci.yml`: PR validation pipeline
+- `version-label-check.yml` (or equivalent job within `ci.yml`)
+- `release.yml`: version calculation, tagging, GitHub Release creation
+
+Publish workflows:
+
+- `friction-core` / `friction-adapters`: `publish.yml` for Maven package deployment
+- `friction-ui`: `publish-ui.yml` (or combined release workflow) for `jpackage` matrix artifacts
+
+## Automated Changelog Generation
+
+Objective: generate release changelogs automatically from commit messages and merged PR metadata.
+
+Baseline approach:
+
+- Generate changelog during release workflow from commits since previous tag.
+- Group entries by semantic label and/or Conventional Commit type where available.
+- Include links to PRs/issues and commit SHAs for traceability.
+
+Recommended inputs:
+
+- Commit messages (prefer Conventional Commit style for cleaner grouping).
+- PR titles and labels (`version:*`, `architecture`, `mvu`, etc.).
+- Merge metadata between `last_tag..new_tag`.
+
+Output targets:
+
+- GitHub Release notes body (primary).
+- Optional `CHANGELOG.md` update in-repo for persistent history.
+
+Operational guardrails:
+
+- If commit messages are inconsistent, fall back to PR-title-first changelog entries.
+- Keep changelog generation deterministic and tied to tag boundaries.
+- Do not require manual edits for normal releases; allow override for exceptional releases.
+
+## Security and Governance Controls
+
+- Branch protection on default branch:
+  - require pull requests
+  - require status checks (`ci`, `version-label-check`)
+  - require up-to-date branch before merge
+- Minimal workflow permissions:
+  - `contents: write` for tagging/releases
+  - `packages: write` only for package-publish jobs
+- Optional protected environments for release/publish approvals
+
+## Operational Notes
+
+- Keep workflow logic deterministic and label-driven.
+- Keep release notes tied to PR and issue references.
+- Prefer reusable composite actions or shared scripts only after first stable pass.
+
+## Implementation Order
+
+1. Add `ci.yml` + version-label validation in all repos.
+2. Enable branch protection requiring those checks.
+3. Add `release.yml` with semantic bump from PR labels.
+4. Add publish workflows:
+   - Maven packages for `friction-core` and `friction-adapters`
+   - `jpackage` release artifacts for `friction-ui`
+5. Dry-run on test tags/branches, then enable for default branch.
+
+## Success Criteria
+
+- No PR merges without passing CI and valid version labels.
+- Every merged release PR produces deterministic semantic version tags/releases.
+- `friction-core` and `friction-adapters` artifacts are available in GitHub Packages.
+- `friction-ui` has downloadable cross-platform release artifacts from GitHub Releases.

--- a/docs/PUBLISH_RUNBOOK.md
+++ b/docs/PUBLISH_RUNBOOK.md
@@ -1,0 +1,181 @@
+# friction-core Publish Runbook (Do This Once, Reuse Forever)
+
+This runbook captures the exact CI/CD setup for publishing `friction-core` to GitHub Packages, including the common failure modes we hit and how to fix them quickly.
+
+## Current Workflow Model
+
+`friction-core` uses 3 workflows:
+
+1. `ci.yml`
+- Trigger: `pull_request`
+- Purpose: build/test + version-label validation
+
+2. `release.yml`
+- Trigger: push to `master`
+- Purpose: compute semver bump from PR labels, update `pom.xml`, commit bump, tag version, generate changelog notes
+
+3. `publish.yml`
+- Trigger: `workflow_run` on successful `Release`
+- Purpose: checkout latest semver tag and publish package to GitHub Packages
+
+## Source of Truth Files
+
+- Workflow files:
+  - `.github/workflows/ci.yml`
+  - `.github/workflows/release.yml`
+  - `.github/workflows/publish.yml`
+- Maven publish target:
+  - `pom.xml` (`distributionManagement`)
+- Workflow docs:
+  - `docs/WORKFLOW_DEV.md`
+  - `docs/VERSIONING.md`
+
+## One-Time GitHub Setup Checklist
+
+Complete these once per repo/org setup.
+
+1. Repository Actions permissions
+- Repo: `friction-core` -> `Settings` -> `Actions` -> `General`
+- Set `Workflow permissions` to `Read and write permissions`
+
+2. Create PAT for package publishing
+- Create PAT from the owner account that owns/publishes packages (`IdelsTak`)
+- Required scopes:
+  - `write:packages`
+  - `read:packages`
+  - `repo` (if repo is private)
+
+3. Add repo secret
+- Repo: `friction-core` -> `Settings` -> `Secrets and variables` -> `Actions`
+- Secret name: `PACKAGES_TOKEN`
+- Secret value: PAT from step 2
+
+4. Verify package/repo access policy (if org restrictions apply)
+- Confirm this repo is allowed to publish packages
+- Confirm package visibility/settings do not block writes from this repo token owner
+
+## Maven Requirements (Must Stay True)
+
+`pom.xml` must include `distributionManagement` with repository id `github`.
+
+Expected section:
+
+```xml
+<distributionManagement>
+  <repository>
+    <id>github</id>
+    <name>GitHub Packages</name>
+    <url>https://maven.pkg.github.com/IdelsTak/friction-core</url>
+  </repository>
+</distributionManagement>
+```
+
+Why this matters:
+- `publish.yml` runs `mvn deploy` (no alternate deployment override).
+- `actions/setup-java` writes Maven credentials for server id `github`.
+- Deploy succeeds only if `distributionManagement.repository.id` matches setup-java `server-id`.
+
+## Workflow Auth Contract
+
+In `publish.yml`, the setup-java step must have:
+- `server-id: github`
+- `server-username: GITHUB_ACTOR`
+- `server-password: PACKAGES_TOKEN`
+- `env.PACKAGES_TOKEN: ${{ secrets.PACKAGES_TOKEN }}`
+
+If this env wiring is missing, Maven will deploy with invalid/missing auth and return `401`.
+
+## Expected Happy Path
+
+1. Merge PR to `master` with exactly one impact label:
+- `version:major` or `version:minor` or `version:patch`
+
+2. `release.yml` runs:
+- resolves PR labels
+- computes next version
+- updates `pom.xml`
+- commits bump
+- creates `vX.Y.Z` tag
+- creates changelog notes
+
+3. `publish.yml` runs (`workflow_run` on Release success):
+- checks out `master`
+- resolves latest semver tag
+- checks out that tag
+- verifies `pom.xml` version equals tag version
+- runs `mvn deploy`
+
+4. Package appears in GitHub Packages.
+
+## Fast Verification Commands
+
+From repo root:
+
+```bash
+actionlint
+yamllint .github/workflows
+```
+
+Quick local Maven check (no publish):
+
+```bash
+mvn -B -ntp -DskipTests verify
+```
+
+## Troubleshooting Matrix
+
+### Symptom A
+`publish.yml` does not run
+
+Checks:
+1. Did `release.yml` run and succeed?
+2. Is `publish.yml` trigger exactly:
+- `on.workflow_run.workflows: ["Release"]`
+- `types: [completed]`
+3. Is publish job gated correctly?
+- `if: github.event.workflow_run.conclusion == 'success'`
+
+### Symptom B
+`401 Unauthorized` on `mvn deploy`
+
+Checks in order:
+1. `PACKAGES_TOKEN` secret exists in repo
+2. PAT scopes are correct (`write:packages`, `read:packages`, and `repo` if private)
+3. PAT owner has rights on target package/repo
+4. `setup-java` receives `PACKAGES_TOKEN` env
+5. `pom.xml` has correct `distributionManagement` with id `github`
+6. `distributionManagement` URL points to exact repo path
+
+### Symptom C
+`pom.xml version (...) does not match tag (...)`
+
+Cause:
+- Release bump/tag and publish trigger got out of sync
+
+Fix:
+1. Verify latest tag points to commit that contains bumped `pom.xml`
+2. Re-run `Release` then `Publish Package`
+3. If needed, correct tag/version alignment in `master`
+
+## Guardrails (Do Not Change Casually)
+
+- Do not remove `distributionManagement` from `pom.xml`.
+- Do not change setup-java `server-id` unless `pom.xml` repository id changes too.
+- Do not move publish trigger back to `on: release` without redesign; use `workflow_run` to keep deterministic chaining.
+- Do not publish with a PAT from an unrelated account lacking package permissions.
+
+## Change Checklist (When Editing Workflows)
+
+After every workflow edit:
+
+1. Run:
+```bash
+actionlint
+yamllint .github/workflows
+```
+
+2. Confirm docs match behavior:
+- `docs/WORKFLOW_DEV.md`
+- `docs/VERSIONING.md`
+
+3. Keep this runbook updated with any new failure modes.

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -48,3 +48,5 @@
 - It checks out latest semver tag and verifies:
   - `pom.xml` version == tag version
 - Publishes Maven package to GitHub Packages using `PACKAGES_TOKEN`.
+- Deploy target is defined in `pom.xml` via `<distributionManagement>` with
+  repository id `github`.

--- a/docs/WORKFLOW_DEV.md
+++ b/docs/WORKFLOW_DEV.md
@@ -61,12 +61,15 @@ What it does:
   - Behavior: resolve semantic bump from PR labels, update `pom.xml`, commit version bump, create tag, generate changelog notes
 - `.github/workflows/publish.yml`
   - Trigger: `workflow_run` for `Release` completion
-  - Behavior: checkout latest tag, verify `pom.xml` version matches tag, publish Maven package
+  - Behavior: checkout latest tag, verify `pom.xml` version matches tag, publish Maven package via `distributionManagement`
 
 ## Authentication and Permissions
 
 - `release.yml` uses `GITHUB_TOKEN` for commit/tag/release-note operations.
 - `publish.yml` uses `PACKAGES_TOKEN` (PAT) for Maven package deployment.
+- `setup-java` writes `settings.xml` credentials for server id `github`:
+  - username source: `GITHUB_ACTOR`
+  - password source: `PACKAGES_TOKEN`
 - Recommended `PACKAGES_TOKEN` scopes:
   - `write:packages`
   - `read:packages`

--- a/pom.xml
+++ b/pom.xml
@@ -31,4 +31,11 @@
    </plugin>
   </plugins>
  </build>
+ <distributionManagement>
+  <repository>
+   <id>github</id>
+   <name>GitHub Packages</name>
+   <url>https://maven.pkg.github.com/IdelsTak/friction-core</url>
+  </repository>
+ </distributionManagement>
 </project>


### PR DESCRIPTION
Improves `friction-core` package publishing reliability by standardizing Maven publish target/config and codifying the runbook.

### Changes
- Added `distributionManagement` to `pom.xml` (`id=github`, GitHub Packages repo URL).
- Switched publish deploy path to use `mvn deploy` with `setup-java` generated credentials.
- Ensured `GITHUB_ACTOR` and `PACKAGES_TOKEN` are available where needed in `publish.yml`.
- Updated workflow/versioning docs for the final auth + deploy model.
- Added `docs/PUBLISH_RUNBOOK.md` and `docs/CI_CD_APPROACH_REPORT.md` inside `friction-core` for direct repo-local access.

### Why
Previous publish failures (`401 Unauthorized`) were caused by inconsistent deploy target/auth wiring. This change aligns workflow credentials and Maven repository configuration into a single, predictable path.

### Validation
- `actionlint` passes
- `yamllint .github/workflows` passes