### PR TITLE
Use GITHUB_TOKEN for friction-core package publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,17 +30,6 @@ jobs:
           ref: master
           fetch-depth: 0
 
-      - name: Require PACKAGES_TOKEN
-        env:
-          PACKAGES_TOKEN: ${{ secrets.PACKAGES_TOKEN }}
-        run: |
-          set -euo pipefail
-          if [[ -z "${PACKAGES_TOKEN:-}" ]]; then
-            echo "Missing required secret: PACKAGES_TOKEN"
-            echo "Create PAT with write:packages (and repo for private repos)."
-            exit 1
-          fi
-
       - name: Resolve latest release tag
         id: tag
         run: |
@@ -77,7 +66,7 @@ jobs:
       - name: Set up JDK
         env:
           GITHUB_ACTOR: ${{ github.actor }}
-          PACKAGES_TOKEN: ${{ secrets.PACKAGES_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         uses: actions/setup-java@v4
         with:
           distribution: temurin
@@ -85,13 +74,13 @@ jobs:
           cache: maven
           server-id: github
           server-username: GITHUB_ACTOR
-          server-password: PACKAGES_TOKEN
+          server-password: GITHUB_TOKEN
           settings-path: ${{ github.workspace }}
 
       - name: Publish Maven package to GitHub Packages
         env:
           GITHUB_ACTOR: ${{ github.actor }}
-          PACKAGES_TOKEN: ${{ secrets.PACKAGES_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           mvn -B -ntp deploy -DskipTests

--- a/docs/PUBLISH_RUNBOOK.md
+++ b/docs/PUBLISH_RUNBOOK.md
@@ -38,21 +38,9 @@ Complete these once per repo/org setup.
 - Repo: `friction-core` -> `Settings` -> `Actions` -> `General`
 - Set `Workflow permissions` to `Read and write permissions`
 
-2. Create PAT for package publishing
-- Create PAT from the owner account that owns/publishes packages (`IdelsTak`)
-- Required scopes:
-  - `write:packages`
-  - `read:packages`
-  - `repo` (if repo is private)
-
-3. Add repo secret
-- Repo: `friction-core` -> `Settings` -> `Secrets and variables` -> `Actions`
-- Secret name: `PACKAGES_TOKEN`
-- Secret value: PAT from step 2
-
-4. Verify package/repo access policy (if org restrictions apply)
+2. Verify package/repo access policy (if org restrictions apply)
 - Confirm this repo is allowed to publish packages
-- Confirm package visibility/settings do not block writes from this repo token owner
+- Confirm package visibility/settings do not block writes from this repo
 
 ## Maven Requirements (Must Stay True)
 
@@ -80,8 +68,8 @@ Why this matters:
 In `publish.yml`, the setup-java step must have:
 - `server-id: github`
 - `server-username: GITHUB_ACTOR`
-- `server-password: PACKAGES_TOKEN`
-- `env.PACKAGES_TOKEN: ${{ secrets.PACKAGES_TOKEN }}`
+- `server-password: GITHUB_TOKEN`
+- `env.GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}`
 
 If this env wiring is missing, Maven will deploy with invalid/missing auth and return `401`.
 
@@ -139,12 +127,11 @@ Checks:
 `401 Unauthorized` on `mvn deploy`
 
 Checks in order:
-1. `PACKAGES_TOKEN` secret exists in repo
-2. PAT scopes are correct (`write:packages`, `read:packages`, and `repo` if private)
-3. PAT owner has rights on target package/repo
-4. `setup-java` receives `PACKAGES_TOKEN` env
-5. `pom.xml` has correct `distributionManagement` with id `github`
-6. `distributionManagement` URL points to exact repo path
+1. Workflow/job permissions include `packages: write`
+2. Repository Actions permissions are set to read/write
+3. `setup-java` receives `GITHUB_TOKEN` env and `server-password: GITHUB_TOKEN`
+4. `pom.xml` has correct `distributionManagement` with id `github`
+5. `distributionManagement` URL points to exact repo path
 
 ### Symptom C
 `pom.xml version (...) does not match tag (...)`
@@ -162,7 +149,8 @@ Fix:
 - Do not remove `distributionManagement` from `pom.xml`.
 - Do not change setup-java `server-id` unless `pom.xml` repository id changes too.
 - Do not move publish trigger back to `on: release` without redesign; use `workflow_run` to keep deterministic chaining.
-- Do not publish with a PAT from an unrelated account lacking package permissions.
+- PATs are for external consumers pulling private packages, not for
+  `friction-core` publishing itself.
 
 ## Change Checklist (When Editing Workflows)
 

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -47,6 +47,6 @@
 - `publish.yml` runs on successful `workflow_run` completion of `Release`.
 - It checks out latest semver tag and verifies:
   - `pom.xml` version == tag version
-- Publishes Maven package to GitHub Packages using `PACKAGES_TOKEN`.
+- Publishes Maven package to GitHub Packages using `GITHUB_TOKEN`.
 - Deploy target is defined in `pom.xml` via `<distributionManagement>` with
   repository id `github`.

--- a/docs/WORKFLOW_DEV.md
+++ b/docs/WORKFLOW_DEV.md
@@ -66,14 +66,10 @@ What it does:
 ## Authentication and Permissions
 
 - `release.yml` uses `GITHUB_TOKEN` for commit/tag/release-note operations.
-- `publish.yml` uses `PACKAGES_TOKEN` (PAT) for Maven package deployment.
+- `publish.yml` uses `GITHUB_TOKEN` for Maven package deployment.
 - `setup-java` writes `settings.xml` credentials for server id `github`:
   - username source: `GITHUB_ACTOR`
-  - password source: `PACKAGES_TOKEN`
-- Recommended `PACKAGES_TOKEN` scopes:
-  - `write:packages`
-  - `read:packages`
-  - `repo` (private repos)
+  - password source: `GITHUB_TOKEN`
 
 ## PR Checks and Label Policy
 
@@ -110,10 +106,11 @@ Symptom:
 
 Cause:
 
-- Missing/invalid `PACKAGES_TOKEN`, or package write access not granted.
+- Repo token lacks package write access, or package/repo permissions deny write.
 
 Resolution:
 
-- Ensure repo secret `PACKAGES_TOKEN` exists and has required scopes.
+- Ensure workflow/job permissions include `packages: write`.
+- Ensure repository Actions permissions are set to read/write.
 - Confirm package/repository access settings allow this repo to publish.
 - Ensure `publish.yml` runs after successful `Release` workflow completion.


### PR DESCRIPTION
Switches `friction-core` package deployment authentication from PAT (`PACKAGES_TOKEN`) to `GITHUB_TOKEN` and updates docs/runbook accordingly.

### Changes
- Removed `PACKAGES_TOKEN` dependency from `publish.yml`.
- Configured `setup-java` and deploy step to use `GITHUB_TOKEN`.
- Updated workflow/versioning/runbook docs to reflect the final publisher auth contract.

### Operational Impact
- Publisher flow no longer requires a PAT secret for same-repo package publishing.
- External consumers may still need PAT depending on package visibility.

### Validation
- `actionlint` passed.
- `yamllint .github/workflows` passed.