### PR TITLE
Harden publish workflow tag/pom version validation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,13 +49,18 @@ jobs:
           set -euo pipefail
           git checkout "${{ steps.tag.outputs.tag }}"
 
+      - name: Install xmlstarlet
+        run: sudo apt-get update && sudo apt-get install -y xmlstarlet
+
       - name: Validate pom.xml matches tag
         run: |
           set -euo pipefail
           tag="${{ steps.tag.outputs.tag }}"
           tag_version="${tag#v}"
           pom_version="$(
-            mvn -q -DforceStdout help:evaluate -Dexpression=project.version
+            xmlstarlet sel -t \
+              -v "/*[local-name()='project']/*[local-name()='version']" \
+              pom.xml
           )"
           if [[ "${pom_version}" != "${tag_version}" ]]; then
             echo "pom.xml version (${pom_version})"
@@ -64,14 +69,10 @@ jobs:
           fi
 
       - name: Set up JDK
-        env:
-          GITHUB_ACTOR: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: '25'
-          cache: maven
           server-id: github
           server-username: GITHUB_ACTOR
           server-password: GITHUB_TOKEN


### PR DESCRIPTION
## What changed
This PR hardens the `friction-core` publish workflow by making tag-to-pom version validation independent of Maven runtime initialization and by simplifying `setup-java` configuration.

## Why
Recent publish failures showed fragile behavior around auth/tooling order. Parsing `pom.xml` directly with `xmlstarlet` avoids invoking Maven just for version reads and makes validation failures clearer.

## Details
- Added an explicit `xmlstarlet` install step in `.github/workflows/publish.yml`.
- Updated validation step to read `project.version` via `xmlstarlet`.
- Removed step-level env injection from `setup-java` to keep auth wiring minimal.
- Removed Maven cache option during stabilization to reduce moving parts.

## Validation
- `actionlint .github/workflows/publish.yml` passes.
- `yamllint .github/workflows/publish.yml` passes.

## Risk/Impact
Low. Changes are isolated to publish workflow behavior and do not affect application runtime code.